### PR TITLE
fix: preserve codex transport identity export

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -124,8 +124,8 @@ from agent.memory_manager import StreamingContextScrubber, build_memory_context_
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.retry_utils import jittered_backoff
 from agent.error_classifier import classify_api_error, FailoverReason
-# Imported for agent.system_prompt._ra() patch contract.
-from agent.prompt_builder import build_nous_subscription_prompt  # noqa: F401
+# Imported for compatibility and agent.system_prompt._ra() patch contract.
+from agent.prompt_builder import DEFAULT_AGENT_IDENTITY, build_nous_subscription_prompt  # noqa: F401
 from agent.model_metadata import (
     fetch_model_metadata,
     estimate_tokens_rough, estimate_messages_tokens_rough, estimate_request_tokens_rough,


### PR DESCRIPTION
## Summary
- Restores the `run_agent.DEFAULT_AGENT_IDENTITY` compatibility export used by the Codex Responses transport.
- Keeps the canonical `agent.system_prompt` forwarder from the upstream-sync closeout intact.

## Validation
- `py -3 -m pytest -o addopts= tests\run_agent\test_codex_xai_oauth_recovery.py tests\run_agent\test_context_token_tracking.py::test_codex_no_cache_fields tests\run_agent\test_provider_parity.py::TestBuildApiKwargsCodex tests\run_agent\test_provider_parity.py::TestProviderRouting::test_routing_not_injected_for_codex tests\run_agent\test_provider_parity.py::TestReasoningEffortDefaults tests\run_agent\test_run_agent.py::TestHandleMaxIterations::test_codex_summary_sanitizes_orphan_tool_results tests\run_agent\test_run_agent_codex_responses.py -q --tb=short`
- `py -3 -m py_compile run_agent.py`
- `uvx ruff check run_agent.py`