### PR TITLE
fix: close upstream sync CI regressions

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -87,6 +87,11 @@ from agent.usage_pricing import (
     format_duration_compact,
     format_token_count_compact,
 )
+from agent.markdown_tables import (
+    is_table_divider,
+    looks_like_table_row,
+    realign_markdown_tables,
+)
 from hermes_cli.banner import _format_context_length
 from hermes_cli.harness import ensure_harness_running
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1016,9 +1016,14 @@ DEFAULT_CONFIG = {
         "tui_auto_resume_recent": False,
         "bell_on_complete": False,
         "show_reasoning": False,
+        "interim_assistant_messages": True,
         "streaming": False,
         "timestamps": False,      # Show [HH:MM] on user and assistant labels
         "final_response_markdown": "strip",  # render | strip | raw
+        "user_message_preview": {
+            "first_lines": 2,
+            "last_lines": 2,
+        },
         # Preserve recent classic CLI output across Ctrl+L, /redraw, and
         # terminal resize full-screen clears. Disable if a terminal emulator
         # behaves badly with replayed scrollback.

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1327,6 +1327,11 @@ def run_doctor(args):
             check_info(step)
     else:
         check_warn("Node.js not found", "(optional, needed for browser tools)")
+
+    if _is_termux():
+        check_info("Termux compatibility fallbacks:")
+        for note in _termux_install_all_fallback_notes():
+            check_info(note)
     
     # npm audit for all Node.js packages
     _npm_bin = _safe_which("npm")

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2189,6 +2189,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         path_entries.extend(_build_wsl_interop_paths(path_entries))
         path_entries.extend(common_bin_paths)
         sane_path = ":".join(path_entries)
+        profile_suffix = f" {profile_arg}" if profile_arg else ""
         return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
@@ -2199,7 +2200,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli gateway run --replace
+ExecStart={python_path} -m hermes_cli{profile_suffix} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2229,6 +2230,7 @@ WantedBy=multi-user.target
     path_entries.extend(_build_wsl_interop_paths(path_entries))
     path_entries.extend(common_bin_paths)
     sane_path = ":".join(path_entries)
+    profile_suffix = f" {profile_arg}" if profile_arg else ""
     return f"""[Unit]
 Description={SERVICE_DESCRIPTION}
 After=network-online.target
@@ -2237,7 +2239,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli gateway run --replace
+ExecStart={python_path} -m hermes_cli{profile_suffix} gateway run --replace
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -2844,12 +2846,7 @@ def generate_launchd_plist() -> str:
 
     <key>ProgramArguments</key>
     <array>
-        <string>{python_path}</string>
-        <string>-m</string>
-        <string>hermes_cli</string>
-        <string>gateway</string>
-        <string>run</string>
-        <string>--replace</string>
+        {prog_args_xml}
     </array>
     
     <key>WorkingDirectory</key>


### PR DESCRIPTION
## Summary
- restore display defaults required by the merged upstream config tests
- print Termux compatibility fallback notes in doctor output
- preserve named profile routing in generated systemd and launchd gateway service definitions
- restore the official markdown table helper imports used by CLI final-response rendering

## Validation
- py -3 -m pytest -o addopts= tests/hermes_cli/test_config.py::TestLoadConfigDefaults::test_returns_defaults_when_no_file tests/hermes_cli/test_config.py::TestInterimAssistantMessageConfig::test_default_config_enables_interim_assistant_messages tests/hermes_cli/test_config.py::TestUserMessagePreviewConfig::test_default_config_preview_line_counts tests/hermes_cli/test_doctor.py::test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected -q --tb=short
- py -3 -m pytest -o addopts= tests/cli/test_cli_markdown_rendering.py -q --tb=short
- direct profile-service generation smoke for generate_systemd_unit(system=False) and generate_launchd_plist()
- py -3 -m py_compile cli.py hermes_cli\config.py hermes_cli\doctor.py hermes_cli\gateway.py
- uvx ruff check cli.py hermes_cli\config.py hermes_cli\doctor.py hermes_cli\gateway.py
- git diff --check origin/main...HEAD
