### PR TITLE
test: clarify provider discovery invariant

### DIFF
--- a/tests/providers/test_plugin_discovery.py
+++ b/tests/providers/test_plugin_discovery.py
@@ -47,7 +47,7 @@ def test_bundled_plugins_discovered():
 
 
 def test_provider_profiles_register():
-    """Discovery registers bundled provider profiles without catalog snapshots."""
+    """Discovery registers bundled provider profiles through stable invariants."""
     _clear_provider_caches()
     from providers import list_providers
 


### PR DESCRIPTION
## Summary
- Clarify the provider-discovery invariant test wording.

## Local checks
- pytest tests/providers/test_plugin_discovery.py -q --timeout-method=thread
- ruff check tests/providers/test_plugin_discovery.py
- ruff format --check tests/providers/test_plugin_discovery.py