### PR TITLE
fix(runtime): port upstream restart, cron, desktop, and gateway boundary fixes

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -454,16 +454,16 @@ def _restore_cron_skill_links(snapshot_dir: Path) -> Dict[str, Any]:
         report["attempted"] = True  # we tried but there was nothing to do
         return report
 
-    # Load and rewrite the live jobs under the scheduler's lock.
+    # Load and rewrite the live jobs under the scheduler's cross-process lock.
     try:
-        from cron.jobs import load_jobs, save_jobs, _jobs_file_lock
+        from cron.jobs import load_jobs, save_jobs, _jobs_lock
     except ImportError as e:
         report["error"] = f"cron module unavailable: {e}"
         return report
 
     report["attempted"] = True
     try:
-        with _jobs_file_lock:
+        with _jobs_lock():
             live_jobs = load_jobs()
             changed = False
 

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -1,0 +1,89 @@
+import { atom } from 'nanostores'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { HermesConnection } from '@/global'
+
+// Keep profile.ts's side-effecting imports inert: the gateway socket layer and
+// the REST query client must not run for real in a unit test.
+const ensureGatewayForProfile = vi.fn(async () => undefined)
+const $gateway = atom<unknown>({ id: 'live-socket' })
+
+vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForProfile }))
+vi.mock('@/hermes', () => ({
+  getProfiles: vi.fn(async () => ({ profiles: [] })),
+  setApiRequestProfile: vi.fn()
+}))
+vi.mock('@/lib/query-client', () => ({ queryClient: { invalidateQueries: vi.fn() } }))
+
+const { $activeGatewayProfile, ensureGatewayProfile } = await import('./profile')
+const { $connection } = await import('./session')
+
+const remoteConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: 'https://hermes-roy.tail.ts.net', mode: 'remote', profile: 'vps-remote', ...over }) as HermesConnection
+
+const localConn = (over: Partial<HermesConnection> = {}): HermesConnection =>
+  ({ baseUrl: '', mode: 'local', profile: 'default', ...over }) as HermesConnection
+
+const getConnection = vi.fn<(profile?: string | null) => Promise<HermesConnection>>()
+
+beforeEach(() => {
+  getConnection.mockReset()
+  ensureGatewayForProfile.mockClear()
+  $gateway.set({ id: 'live-socket' })
+  $activeGatewayProfile.set('default')
+  $connection.set(localConn())
+  vi.stubGlobal('window', { hermesDesktop: { getConnection } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  $connection.set(null)
+})
+
+describe('ensureGatewayProfile connection sync (#46651)', () => {
+  it('refreshes $connection to the remote descriptor when activating a remote pool profile', async () => {
+    // Regression: the primary window backend is local, so $connection.mode is
+    // "local". Activating the remote profile must flip it to "remote"; without
+    // this, image attach uses path-based image.attach against the remote
+    // gateway ("image not found: C:\\...") instead of image.attach_bytes.
+    getConnection.mockResolvedValue(remoteConn())
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('vps-remote')
+    expect(getConnection).toHaveBeenCalledWith('vps-remote')
+    expect($connection.get()?.mode).toBe('remote')
+    expect($connection.get()?.profile).toBe('vps-remote')
+  })
+
+  it('resyncs $connection back to local when returning to the default profile', async () => {
+    $activeGatewayProfile.set('vps-remote')
+    $connection.set(remoteConn())
+    getConnection.mockResolvedValue(localConn())
+
+    await ensureGatewayProfile('default')
+
+    expect(getConnection).toHaveBeenCalledWith('default')
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('leaves the prior connection intact when the descriptor fetch fails', async () => {
+    getConnection.mockRejectedValue(new Error('backend unreachable'))
+
+    await ensureGatewayProfile('vps-remote')
+
+    // Best-effort: boot/reconnect resyncs later; we must not null it out here.
+    expect($connection.get()?.mode).toBe('local')
+  })
+
+  it('does not churn $connection when the target is already the active profile', async () => {
+    $activeGatewayProfile.set('vps-remote')
+    $connection.set(remoteConn())
+
+    await ensureGatewayProfile('vps-remote')
+
+    expect(getConnection).not.toHaveBeenCalled()
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
+    expect($connection.get()?.mode).toBe('remote')
+  })
+})

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -12,6 +12,7 @@ import {
   storedStringRecord
 } from '@/lib/storage'
 import { $gateway, ensureGatewayForProfile } from '@/store/gateway'
+import { setConnection } from '@/store/session'
 import type { ProfileInfo } from '@/types/hermes'
 
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
@@ -178,6 +179,32 @@ export const $gatewaySwapTarget = atom<string | null>(null)
 
 let gatewaySwitch: Promise<void> | null = null
 
+// Keep the renderer's $connection (mode / baseUrl / profile) in lockstep with
+// the profile the live gateway is now on. $connection seeds from the PRIMARY
+// (window) backend at boot and otherwise only refreshes on a sleep/wake
+// reconnect, so activating a *background* profile left $connection describing
+// the primary, with the wrong `mode` for everything that branches on
+// local-vs-remote. Headline symptom: with a local primary and a remote pool
+// profile active, image attachments went out via the path-based `image.attach`
+// instead of `image.attach_bytes`, handing the remote gateway a client-only
+// path it can't resolve ("image not found: C:\\..."), while the /api/fs/* file
+// browser and /api/media fetches targeted the wrong machine (#46651).
+// Best-effort: a failed descriptor fetch leaves the prior connection intact for
+// boot/reconnect to resync.
+async function syncConnectionToActiveProfile(profile: string): Promise<void> {
+  const getConnection = window.hermesDesktop?.getConnection
+
+  if (!getConnection) {
+    return
+  }
+
+  try {
+    setConnection(await getConnection(profile))
+  } catch {
+    // Leave the prior connection in place; boot/reconnect resyncs it later.
+  }
+}
+
 // Make `profile`'s backend the active gateway, lazily opening its socket if it
 // isn't live yet. Unlike the old single-socket swap, background profiles keep
 // their sockets — so their sessions keep streaming concurrently. A null/empty
@@ -218,6 +245,9 @@ export async function ensureGatewayProfile(profile: string | null | undefined): 
     // the active gateway at it — without closing the profile you came from.
     await ensureGatewayForProfile(target)
     $activeGatewayProfile.set(target)
+    // The active backend just changed; resync $connection so remote-aware
+    // paths (image.attach_bytes vs image.attach, /api/fs/*, /api/media) follow.
+    await syncConnectionToActiveProfile(target)
   })()
 
   try {

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -5,6 +5,7 @@ Jobs are stored in ~/.hermes/cron/jobs.json
 Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 """
 
+import contextlib
 import copy
 import json
 import logging
@@ -14,6 +15,19 @@ import threading
 import os
 import re
 import uuid
+
+# Cross-process advisory file locking for jobs.json critical sections.
+# fcntl is Unix-only; on Windows fall back to msvcrt. Either may be absent,
+# in which case _jobs_lock() degrades to in-process locking only (the old
+# behaviour) rather than failing.
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - non-Unix
+    fcntl = None
+try:
+    import msvcrt
+except ImportError:  # pragma: no cover - non-Windows
+    msvcrt = None
 from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -41,9 +55,78 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
-_jobs_file_lock = threading.Lock()
+_jobs_file_lock = threading.RLock()
+_jobs_lock_state = threading.local()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
+
+
+def _jobs_lock_file() -> Path:
+    """Return the advisory lock path for the current cron directory."""
+    return CRON_DIR / ".jobs.lock"
+
+
+@contextlib.contextmanager
+def _jobs_lock():
+    """Serialize a load_jobs→modify→save_jobs critical section.
+
+    Combines the in-process threading lock (cheap mutual exclusion between
+    the gateway's parallel tick threads) with a cross-process advisory file
+    lock on ``<cron dir>/.jobs.lock`` (mutual exclusion between the gateway process
+    and standalone ``hermes`` CLI invocations, which previously shared no lock
+    at all — a `cron pause` could be silently clobbered by a concurrent
+    gateway write, leaving a "paused" job still firing).
+
+    The flock is blocking, but every critical section that uses it is short
+    (field updates only — no agent execution), so contention resolves in
+    milliseconds. If neither fcntl nor msvcrt is available the manager still
+    provides in-process locking, matching the historical behaviour.
+
+    Nested calls in the same thread reuse the held lock so legacy callers that
+    invoke save_jobs() inside a broader mutation section don't deadlock or try
+    to reacquire the advisory file lock.
+    """
+    depth = getattr(_jobs_lock_state, "depth", 0)
+    if depth:
+        _jobs_lock_state.depth = depth + 1
+        try:
+            yield
+        finally:
+            _jobs_lock_state.depth -= 1
+        return
+
+    with _jobs_file_lock:
+        _jobs_lock_state.depth = 1
+        lock_fd = None
+        try:
+            try:
+                ensure_dirs()
+                lock_fd = open(_jobs_lock_file(), "a+", encoding="utf-8")
+                lock_fd.seek(0)
+                if fcntl is not None:
+                    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                elif msvcrt is not None:
+                    getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_LOCK"), 1)
+            except (OSError, IOError) as e:
+                # Never let a locking failure take down cron writes — fall back to
+                # in-process-only protection (still held via _jobs_file_lock).
+                logger.warning("jobs.json cross-process lock unavailable (%s); "
+                               "proceeding with in-process lock only", e)
+            try:
+                yield
+            finally:
+                if lock_fd is not None:
+                    try:
+                        if fcntl is not None:
+                            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                        elif msvcrt is not None:
+                            getattr(msvcrt, "locking")(lock_fd.fileno(), getattr(msvcrt, "LK_UNLCK"), 1)
+                    except (OSError, IOError):
+                        pass
+                    finally:
+                        lock_fd.close()
+        finally:
+            _jobs_lock_state.depth = 0
 
 # Fields on a cron job that must never change after creation. ``id`` is used
 # as a filesystem path component under ``OUTPUT_DIR``; allowing it to be
@@ -468,8 +551,8 @@ def load_jobs() -> List[Dict[str, Any]]:
     )
 
 
-def save_jobs(jobs: List[Dict[str, Any]]):
-    """Save all jobs to storage."""
+def _save_jobs_unlocked(jobs: List[Dict[str, Any]]):
+    """Save all jobs to storage. Caller must hold _jobs_lock()."""
     ensure_dirs()
     fd, tmp_path = tempfile.mkstemp(dir=str(JOBS_FILE.parent), suffix='.tmp', prefix='.jobs_')
     try:
@@ -485,6 +568,12 @@ def save_jobs(jobs: List[Dict[str, Any]]):
         except OSError:
             pass
         raise
+
+
+def save_jobs(jobs: List[Dict[str, Any]]):
+    """Save all jobs to storage."""
+    with _jobs_lock():
+        _save_jobs_unlocked(jobs)
 
 
 def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
@@ -670,9 +759,10 @@ def create_job(
         "workdir": normalized_workdir,
     }
 
-    jobs = load_jobs()
-    jobs.append(job)
-    save_jobs(jobs)
+    with _jobs_lock():
+        jobs = load_jobs()
+        jobs.append(job)
+        save_jobs(jobs)
 
     return job
 
@@ -743,49 +833,50 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
-    jobs = load_jobs()
-    for i, job in enumerate(jobs):
-        if job["id"] != job_id:
-            continue
+    with _jobs_lock():
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
 
-        # Validate / normalize workdir if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "workdir" in updates:
-            _wd = updates["workdir"]
-            if _wd in {None, "", False}:
-                updates["workdir"] = None
-            else:
-                updates["workdir"] = _normalize_workdir(_wd)
+            # Validate / normalize workdir if present in updates.  Empty string
+            # or None both mean "clear the field" (restore old behaviour).
+            if "workdir" in updates:
+                _wd = updates["workdir"]
+                if _wd in {None, "", False}:
+                    updates["workdir"] = None
+                else:
+                    updates["workdir"] = _normalize_workdir(_wd)
 
-        updated = _apply_skill_fields({**job, **updates})
-        schedule_changed = "schedule" in updates
+            updated = _apply_skill_fields({**job, **updates})
+            schedule_changed = "schedule" in updates
 
-        if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
-            updated["skills"] = normalized_skills
-            updated["skill"] = normalized_skills[0] if normalized_skills else None
+            if "skills" in updates or "skill" in updates:
+                normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+                updated["skills"] = normalized_skills
+                updated["skill"] = normalized_skills[0] if normalized_skills else None
 
-        if schedule_changed:
-            updated_schedule = updated["schedule"]
-            # The API may pass schedule as a raw string (e.g. "every 10m")
-            # instead of a pre-parsed dict.  Normalize it the same way
-            # create_job() does so downstream code can call .get() safely.
-            if isinstance(updated_schedule, str):
-                updated_schedule = parse_schedule(updated_schedule)
-                updated["schedule"] = updated_schedule
-            updated["schedule_display"] = updates.get(
-                "schedule_display",
-                updated_schedule.get("display", updated.get("schedule_display")),
-            )
-            if updated.get("state") != "paused":
-                updated["next_run_at"] = compute_next_run(updated_schedule)
+            if schedule_changed:
+                updated_schedule = updated["schedule"]
+                # The API may pass schedule as a raw string (e.g. "every 10m")
+                # instead of a pre-parsed dict.  Normalize it the same way
+                # create_job() does so downstream code can call .get() safely.
+                if isinstance(updated_schedule, str):
+                    updated_schedule = parse_schedule(updated_schedule)
+                    updated["schedule"] = updated_schedule
+                updated["schedule_display"] = updates.get(
+                    "schedule_display",
+                    updated_schedule.get("display", updated.get("schedule_display")),
+                )
+                if updated.get("state") != "paused":
+                    updated["next_run_at"] = compute_next_run(updated_schedule)
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
-            updated["next_run_at"] = compute_next_run(updated["schedule"])
+            if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+                updated["next_run_at"] = compute_next_run(updated["schedule"])
 
-        jobs[i] = updated
-        save_jobs(jobs)
-        return _normalize_job_record(jobs[i])
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(jobs[i])
     return None
 
 
@@ -847,19 +938,20 @@ def remove_job(job_id: str) -> bool:
     if not job:
         return False
     canonical_id = job["id"]
-    jobs = load_jobs()
-    original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != canonical_id]
-    if len(jobs) < original_len:
-        # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
-        # left over from before the create-time guard) fails closed without
-        # half-applying the removal.
-        job_output_dir = _job_output_dir(canonical_id)
-        save_jobs(jobs)
-        # Clean up output directory to prevent orphaned dirs accumulating
-        if job_output_dir.exists():
-            shutil.rmtree(job_output_dir)
-        return True
+    with _jobs_lock():
+        jobs = load_jobs()
+        original_len = len(jobs)
+        jobs = [j for j in jobs if j["id"] != canonical_id]
+        if len(jobs) < original_len:
+            # Resolve the output dir BEFORE saving so a legacy unsafe ID (e.g.
+            # left over from before the create-time guard) fails closed without
+            # half-applying the removal.
+            job_output_dir = _job_output_dir(canonical_id)
+            save_jobs(jobs)
+            # Clean up output directory to prevent orphaned dirs accumulating
+            if job_output_dir.exists():
+                shutil.rmtree(job_output_dir)
+            return True
     return False
 
 
@@ -874,7 +966,7 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
     """
-    with _jobs_file_lock:
+    with _jobs_lock():
         jobs = load_jobs()
         for i, job in enumerate(jobs):
             if job["id"] == job_id:
@@ -948,7 +1040,7 @@ def advance_next_run(job_id: str) -> bool:
 
     Returns True if next_run_at was advanced, False otherwise.
     """
-    with _jobs_file_lock:
+    with _jobs_lock():
         jobs = load_jobs()
         for job in jobs:
             if job["id"] == job_id:
@@ -973,12 +1065,12 @@ def get_due_jobs() -> List[Dict[str, Any]]:
     the job is fast-forwarded to the next future run instead of firing
     immediately.  This prevents a burst of missed jobs on gateway restart.
     """
-    with _jobs_file_lock:
+    with _jobs_lock():
         return _get_due_jobs_locked()
 
 
 def _get_due_jobs_locked() -> List[Dict[str, Any]]:
-    """Inner implementation of get_due_jobs(); must be called with _jobs_file_lock held."""
+    """Inner implementation of get_due_jobs(); must be called with _jobs_lock held."""
     now = _hermes_now()
     raw_jobs = load_jobs()
     jobs = [_apply_skill_fields(j) for j in copy.deepcopy(raw_jobs)]
@@ -1158,7 +1250,7 @@ def rewrite_skill_refs(
     if not consolidated and not pruned_set:
         return {"rewrites": [], "jobs_updated": 0, "jobs_scanned": 0}
 
-    with _jobs_file_lock:
+    with _jobs_lock():
         jobs = load_jobs()
         rewrites: List[Dict[str, Any]] = []
         changed = False

--- a/docker/stage2-hook.sh
+++ b/docker/stage2-hook.sh
@@ -316,6 +316,7 @@ as_hermes mkdir -p \
     "$HERMES_HOME/cron" \
     "$HERMES_HOME/sessions" \
     "$HERMES_HOME/logs" \
+    "$HERMES_HOME/logs/gateways" \
     "$HERMES_HOME/hooks" \
     "$HERMES_HOME/memories" \
     "$HERMES_HOME/skills" \

--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -17,6 +17,57 @@ from utils import atomic_json_write
 logger = logging.getLogger(__name__)
 
 DIRECTORY_PATH = get_hermes_home() / "channel_directory.json"
+# User-maintained friendly-name overlay. The directory is fully regenerated
+# from live adapters + session data on a timer, so hand-edits to
+# channel_directory.json don't survive. Aliases declared here are re-applied
+# on every build AND every load, giving durable human-friendly names (and
+# letting you pre-name a chat before it has produced any traffic).
+# Format: {"<platform>": {"<chat_id>": "<friendly name>", ...}, ...}
+CHANNEL_ALIASES_PATH = get_hermes_home() / "channel_aliases.json"
+
+
+def _load_channel_aliases() -> Dict[str, Dict[str, str]]:
+    if not CHANNEL_ALIASES_PATH.exists():
+        return {}
+    try:
+        with open(CHANNEL_ALIASES_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _apply_channel_aliases(platforms: Dict[str, Any]) -> None:
+    """Overlay friendly names onto directory entries by chat_id.
+
+    Renames matching entries in place; injects a placeholder entry for an
+    aliased id that hasn't been discovered yet (so a freshly-created group is
+    addressable by name before its first message). Mutates *platforms*.
+    """
+    aliases = _load_channel_aliases()
+    for plat_name, id_map in aliases.items():
+        if not isinstance(id_map, dict):
+            continue
+        entries = platforms.setdefault(plat_name, [])
+        if not isinstance(entries, list):
+            continue
+        for chat_id, friendly in id_map.items():
+            if not isinstance(friendly, str) or not friendly.strip():
+                continue
+            chat_id = str(chat_id)
+            friendly = friendly.strip()
+            matched = False
+            for e in entries:
+                if isinstance(e, dict) and e.get("id") == chat_id:
+                    e["name"] = friendly
+                    matched = True
+            if not matched:
+                entries.append({
+                    "id": chat_id,
+                    "name": friendly,
+                    "type": "group" if str(chat_id).endswith("@g.us") else "dm",
+                    "thread_id": None,
+                })
 
 
 def _normalize_channel_query(value: str) -> str:
@@ -95,6 +146,9 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 platforms[entry.name] = _build_from_sessions(entry.name)
     except Exception:
         pass
+
+    # Overlay user-maintained friendly names before persisting.
+    _apply_channel_aliases(platforms)
 
     directory = {
         "updated_at": datetime.now().isoformat(),
@@ -247,12 +301,20 @@ def _build_from_sessions(platform_name: str) -> List[Dict[str, str]]:
 def load_directory() -> Dict[str, Any]:
     """Load the cached channel directory from disk."""
     if not DIRECTORY_PATH.exists():
-        return {"updated_at": None, "platforms": {}}
+        base = {"updated_at": None, "platforms": {}}
+        _apply_channel_aliases(base["platforms"])
+        return base
     try:
         with open(DIRECTORY_PATH, encoding="utf-8") as f:
-            return json.load(f)
+            data = json.load(f)
+        # Re-apply aliases on read so friendly names take effect immediately,
+        # even between timed rebuilds and for brand-new alias entries.
+        _apply_channel_aliases(data.setdefault("platforms", {}))
+        return data
     except Exception:
-        return {"updated_at": None, "platforms": {}}
+        base = {"updated_at": None, "platforms": {}}
+        _apply_channel_aliases(base["platforms"])
+        return base
 
 
 def lookup_channel_type(platform_name: str, chat_id: str) -> Optional[str]:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -510,6 +510,7 @@ _QUICK_STATE_FILES = (
     "cron/jobs.json",
     "gateway_state.json",
     "channel_directory.json",
+    "channel_aliases.json",
     "processes.json",
     # Pairing stores (generic + per-platform JSONs outside state.db)
     "pairing",                          # legacy location (gateway/pairing.py)

--- a/hermes_cli/container_boot.py
+++ b/hermes_cli/container_boot.py
@@ -28,11 +28,14 @@ from typing import Literal, Sequence
 
 log = logging.getLogger(__name__)
 
-# Only this prior state triggers automatic restart. Everything else
+# Only this desired state triggers automatic restart. Everything else
 # (startup_failed, starting, stopped, missing) registers the slot in
 # the down state and waits for explicit user action — this avoids the
 # crash-loop where a broken gateway keeps being restarted across
-# `docker restart` cycles.
+# `docker restart` cycles. Older installs only have gateway_state;
+# newer lifecycle commands persist desired_state separately so a transient
+# runtime state (draining/startup_failed) does not erase the operator's
+# durable start/stop intent across pod/container recreation.
 _AUTOSTART_STATES = frozenset({"running"})
 
 # Stale runtime files we sweep before recreating service slots. These
@@ -104,7 +107,7 @@ def reconcile_profile_gateways(
         container_argv=container_argv,
         dry_run=dry_run,
     )
-    default_prior_state = legacy_default_state or _read_prior_state(hermes_home)
+    default_prior_state = legacy_default_state or _read_desired_state(hermes_home)
     default_should_start = default_prior_state in _AUTOSTART_STATES
     if not dry_run:
         _cleanup_stale_runtime_files(hermes_home)
@@ -139,7 +142,7 @@ def reconcile_profile_gateways(
                 )
                 continue
 
-            prior_state = _read_prior_state(entry)
+            prior_state = _read_desired_state(entry)
             should_start = prior_state in _AUTOSTART_STATES
 
             if not dry_run:
@@ -188,6 +191,7 @@ def _maybe_migrate_legacy_gateway_run_state(
         import time
         state_file.write_text(json.dumps({
             "gateway_state": "running",
+            "desired_state": "running",
             "timestamp": int(time.time()),
             "migrated_from": "legacy-container-cmd",
         }) + "\n")
@@ -203,8 +207,15 @@ def _read_container_argv() -> tuple[str, ...]:
     return tuple(part.decode("utf-8", "replace") for part in raw.split(b"\0") if part)
 
 
-def _is_legacy_gateway_run_request(argv: Sequence[str]) -> bool:
-    """Return True for Docker commands equivalent to `gateway run`."""
+def _strip_container_argv_prefix(argv: Sequence[str]) -> list[str]:
+    """Strip the s6/wrapper prefix off PID 1 argv, leaving the hermes args.
+
+    The container PID 1 argv looks like
+    ``/init /opt/hermes/docker/main-wrapper.sh <subcommand> [args...]`` and
+    the wrapper re-execs ``hermes <subcommand>``. Peel ``init`` →
+    ``main-wrapper.sh`` → ``hermes`` so callers can match on the bare
+    subcommand. Shared by the legacy-gateway and dashboard role detectors.
+    """
     args = list(argv)
     if args and Path(args[0]).name == "init":
         args = args[1:]
@@ -212,20 +223,58 @@ def _is_legacy_gateway_run_request(argv: Sequence[str]) -> bool:
         args = args[1:]
     if args and Path(args[0]).name == "hermes":
         args = args[1:]
+    return args
+
+
+def _is_legacy_gateway_run_request(argv: Sequence[str]) -> bool:
+    """Return True for Docker commands equivalent to `gateway run`."""
+    args = _strip_container_argv_prefix(argv)
     if "--no-supervise" in args:
         return False
     return len(args) >= 2 and args[0] == "gateway" and args[1] == "run"
 
 
-def _read_prior_state(profile_dir: Path) -> str | None:
-    """Read gateway_state.json's ``gateway_state`` field, or None if
-    missing or unparseable. Unparseable counts as "no prior state" so
-    we don't bork the whole reconciliation on a corrupt file."""
+def _is_dashboard_container(argv: Sequence[str]) -> bool:
+    """Return True when the container's command is the dashboard.
+
+    A dashboard-only container (``hermes dashboard ...``) never spawns or
+    supervises per-profile gateways — that is the gateway container's job.
+    Reconciling profile gateway s6 slots there is not just wasted work: when
+    the gateway and dashboard containers share a bind-mounted HERMES_HOME,
+    both race to ``flock()`` the same ``logs/gateways/<profile>/lock`` files,
+    producing "Resource busy" failures and an s6-log restart storm. So the
+    dashboard container skips reconciliation entirely.
+
+    Detected from PID 1 argv (``/proc/1/cmdline``) rather than an operator
+    flag: the role is a fact about the container's command, not a tunable,
+    and a flag can be forgotten in a hand-written compose/k8s manifest —
+    reintroducing the exact storm this prevents. Mirrors the argv handling
+    in :func:`_is_legacy_gateway_run_request`.
+    """
+    args = _strip_container_argv_prefix(argv)
+    return bool(args) and args[0] == "dashboard"
+
+
+def _read_desired_state(profile_dir: Path) -> str | None:
+    """Read the persisted gateway desired state for reconciliation.
+
+    Newer state files carry ``desired_state``: operator intent written by
+    s6 lifecycle commands. Older files only carry ``gateway_state``; keep
+    that as a compatibility fallback so existing running/stopped profiles
+    preserve their behavior until the next explicit start/stop.
+
+    Missing or unparseable files count as "no desired state" so we don't
+    bork the whole reconciliation on a corrupt file.
+    """
     state_file = profile_dir / "gateway_state.json"
     if not state_file.exists():
         return None
     try:
-        return json.loads(state_file.read_text()).get("gateway_state")
+        data = json.loads(state_file.read_text())
+        desired_state = data.get("desired_state")
+        if desired_state is not None:
+            return desired_state
+        return data.get("gateway_state")
     except (OSError, json.JSONDecodeError):
         log.warning(
             "could not read %s; treating as no prior state", state_file,
@@ -378,6 +427,22 @@ _LOG_ROTATE_BYTES = 256 * 1024
 
 def main() -> int:
     """Entry point invoked from /etc/cont-init.d/02-reconcile-profiles."""
+    # A dashboard-only container never spawns or supervises per-profile
+    # gateways, so reconciling their s6 slots here is pure waste — and
+    # actively harmful: when the gateway and dashboard containers share a
+    # bind-mounted HERMES_HOME, both race to flock() the same s6-log lock
+    # files under logs/gateways/<profile>/lock, producing "Resource busy"
+    # failures and a restart storm. Detect the role from PID 1 argv and
+    # skip reconciliation in the dashboard container. No operator flag:
+    # the role is a fact about the container's command, and a flag can be
+    # forgotten in a hand-written manifest, reintroducing the storm.
+    if _is_dashboard_container(_read_container_argv()):
+        print(
+            "reconcile: skipping (dashboard container — does not need "
+            "per-profile gateways)"
+        )
+        return 0
+
     hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
     scandir = Path(os.environ.get("S6_PROFILE_GATEWAY_SCANDIR", "/run/service"))
     actions = reconcile_profile_gateways(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -464,8 +464,19 @@ def _apply_profile_override() -> None:
         if Path(hermes_home_env).parent.name == "profiles":
             return
 
-    # 2. If no flag, check active_profile in the hermes root
-    if profile_name is None:
+    # 2. If no flag, check active_profile in the hermes root.
+    #
+    # EXCEPTION: a supervised s6 gateway child (exported by the container
+    # run-script as HERMES_S6_SUPERVISED_CHILD=1) must NOT follow the sticky
+    # active_profile. Each supervised slot has a fixed profile identity: named
+    # slots pass ``-p <name>`` explicitly (handled in step 1 above), and the
+    # reserved ``gateway-default`` slot runs bare ``hermes gateway run`` to mean
+    # "the root HERMES_HOME profile". If the reserved default child read
+    # active_profile here, switching the active profile (e.g. via the dashboard)
+    # would silently redirect the default gateway into that profile — yielding a
+    # duplicate gateway for the active profile and no real default gateway. See
+    # the "Docker & Profiles & Dashboard" report.
+    if profile_name is None and not os.environ.get("HERMES_S6_SUPERVISED_CHILD"):
         try:
             from hermes_constants import get_default_hermes_root
 
@@ -10929,8 +10940,24 @@ def cmd_dashboard(args):
         if getattr(args, "skip_build", False):
             reexec_argv.append("--skip-build")
         env = os.environ.copy()
-        # Drop the profile HERMES_HOME so the child binds the machine root.
-        env.pop("HERMES_HOME", None)
+        # Pin the child to the machine ROOT, not the launching profile's
+        # HERMES_HOME.  We must resolve the root explicitly instead of just
+        # dropping HERMES_HOME: in the Docker layout the machine root is
+        # /opt/data (set via `ENV HERMES_HOME=/opt/data`), so an unset
+        # HERMES_HOME falls back to $HOME/.hermes = /opt/data/.hermes — an
+        # empty, auto-seeded home where the dashboard sees only the default
+        # profile and the install-method stamp is missing (so the Docker
+        # update-button guard also misfires).  get_default_hermes_root()
+        # returns the root for both layouts: ~/.hermes for a standard install
+        # and /opt/data for Docker (it strips a trailing profiles/<name>).
+        # See the support report for the double-mount workaround this avoids.
+        try:
+            from hermes_constants import get_default_hermes_root
+            env["HERMES_HOME"] = str(get_default_hermes_root())
+        except Exception:
+            # Best-effort: if root resolution fails, fall back to the prior
+            # behaviour (drop HERMES_HOME) rather than block the reroute.
+            env.pop("HERMES_HOME", None)
         # On Windows, os.execvpe() does not truly replace the process — it
         # spawns via CreateProcess then the parent exits.  Under Python 3.14+
         # this can crash with STATUS_ACCESS_VIOLATION (0xC0000005) when

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1234,7 +1234,7 @@ def _maybe_register_gateway_service(profile_name: str) -> None:
     if not mgr.supports_runtime_registration():
         return  # host backend; no-op
     try:
-        mgr.register_profile_gateway(profile_name)
+        mgr.register_profile_gateway(profile_name, start_now=False)
     except ValueError:
         # Already registered (e.g. the container-boot reconciler ran
         # first and brought up a stale slot). That's fine.

--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -77,6 +77,7 @@ class ServiceManager(Protocol):
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None: ...
     def unregister_profile_gateway(self, profile: str) -> None: ...
     def list_profile_gateways(self) -> list[str]: ...
@@ -86,7 +87,8 @@ def detect_service_manager() -> ServiceManagerKind:
     """Detect which service manager is available in this environment.
 
     Returns:
-        "s6" — inside a container when /init is s6-svscan (Phase 2+)
+        "s6" — s6-svscan is PID 1 (s6-overlay image; Docker, Podman, or a
+               Fly Firecracker microVM)
         "windows" — native Windows host
         "launchd" — macOS host
         "systemd" — Linux host with a working user/system bus
@@ -100,14 +102,20 @@ def detect_service_manager() -> ServiceManagerKind:
     # Imports deferred so importing this module doesn't drag in the
     # whole gateway dependency graph for callers that only need the
     # Protocol type or validate_profile_name().
-    from hermes_constants import is_container
     from hermes_cli.gateway import (
         is_macos,
         is_windows,
         supports_systemd_services,
     )
 
-    if is_container() and _s6_running():
+    # Gate on _s6_running() alone (PID 1 comm == s6-svscan AND /run/s6/basedir),
+    # NOT is_container(): the latter only detects Docker/Podman/lxc, so it is
+    # False on Fly's Firecracker microVMs even though s6-overlay is PID 1 there.
+    # That false negative made the whole s6 dispatch path inert on Fly, so
+    # `hermes gateway start/stop/restart` fell through to host code that spawns
+    # a foreground gateway competing with the supervised one. _s6_running() is
+    # already an s6-overlay-specific signal, so the container gate was redundant.
+    if _s6_running():
         return "s6"
     if is_windows():
         return "windows"
@@ -175,6 +183,7 @@ class _RegistrationUnsupportedMixin:
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         raise NotImplementedError(
             f"{type(self).__name__} does not support runtime profile "
@@ -324,6 +333,62 @@ def get_service_manager() -> ServiceManager:
 # automatic supervision on the next rescan.
 S6_DYNAMIC_SCANDIR = Path("/run/service")
 S6_SERVICE_PREFIX = "gateway-"
+
+
+def _profile_dir_for_gateway_service(name: str) -> Path:
+    """Resolve ``gateway-<profile>`` to its persistent profile directory.
+
+    s6 lifecycle commands may be invoked from any active profile, including
+    ``gateway stop --all``. Do not write the caller's HERMES_HOME blindly;
+    derive the shared profile root from the current HERMES_HOME and map the
+    service suffix to either the root default profile or
+    ``<root>/profiles/<profile>``.
+    """
+    import os
+
+    profile = name[len(S6_SERVICE_PREFIX):] if name.startswith(S6_SERVICE_PREFIX) else name
+    validate_profile_name(profile)
+    hermes_home = Path(os.environ.get("HERMES_HOME", "/opt/data"))
+    if hermes_home.parent.name == "profiles":
+        root = hermes_home.parent.parent
+    else:
+        root = hermes_home
+    return root if profile == "default" else root / "profiles" / profile
+
+
+def _write_gateway_desired_state(name: str, desired_state: str) -> None:
+    """Persist durable s6 gateway intent next to runtime status.
+
+    ``gateway_state`` remains the volatile runtime field written by the
+    gateway process. ``desired_state`` records the operator's start/stop
+    intent so container-boot reconciliation can restore the correct s6
+    want-up/want-down state after pod recreation even if the previous runtime
+    state was transient (draining, startup_failed, etc.). The write is
+    best-effort: a failed persistence attempt must not prevent immediate s6
+    lifecycle control.
+    """
+    import json
+    import time
+
+    profile_dir = _profile_dir_for_gateway_service(name)
+    state_file = profile_dir / "gateway_state.json"
+    try:
+        if not profile_dir.exists():
+            return
+        try:
+            data = json.loads(state_file.read_text()) if state_file.exists() else {}
+            if not isinstance(data, dict):
+                data = {}
+        except (OSError, json.JSONDecodeError):
+            data = {}
+        data["desired_state"] = desired_state
+        data["updated_at"] = int(time.time())
+        tmp = state_file.with_suffix(state_file.suffix + ".tmp")
+        tmp.write_text(json.dumps(data, separators=(",", ":")) + "\n")
+        tmp.replace(state_file)
+    except OSError:
+        return
+
 
 # s6-overlay installs its binaries under /command/ and only adds that
 # directory to PATH for processes started under the supervision tree
@@ -680,7 +745,17 @@ class S6ServiceManager:
             f': "${{HERMES_HOME:=/opt/data}}"\n'
             f'log_dir="$HERMES_HOME/logs/gateways/{prof}"\n'
             f'mkdir -p "$log_dir"\n'
+            # The gateways/ parent must be chowned too (non-recursively):
+            # `mkdir -p` creates it root-owned on a root-context boot, and a
+            # leaf-only chown leaves it that way — every profile registered
+            # later then runs its log service as hermes and crash-loops on
+            # `mkdir: Permission denied`. The parent chown runs on every
+            # root-context boot, so it also heals volumes already poisoned
+            # by older images. Non-recursive on purpose: sibling profile
+            # dirs are each managed by their own log/run. See #45258.
+            f'chown hermes:hermes "$HERMES_HOME/logs/gateways" 2>/dev/null || true\n'
             f'chown -R hermes:hermes "$log_dir" 2>/dev/null || true\n'
+            f'rm -f "$log_dir/lock"\n'
             # Skip the drop when already non-root (CAP_SETGID).
             f'[ "$(id -u)" = 0 ] || exec s6-log 1 n10 s1000000 T "$log_dir"\n'
             f'exec s6-setuidgid hermes s6-log 1 n10 s1000000 T "$log_dir"\n'
@@ -743,6 +818,7 @@ class S6ServiceManager:
                 (permission denied on the supervise FIFO, timeout, etc.).
         """
         self._run_svc("-u", "start", name)
+        _write_gateway_desired_state(name, "running")
 
     def _supervised_pid(self, name: str) -> int | None:
         """Return the PID of the supervised gateway process, or None.
@@ -794,6 +870,7 @@ class S6ServiceManager:
             except Exception:
                 pass
         self._run_svc("-d", "stop", name)
+        _write_gateway_desired_state(name, "stopped")
 
     def restart(self, name: str) -> None:
         """Restart a registered service (``s6-svc -t`` = SIGTERM).
@@ -803,6 +880,7 @@ class S6ServiceManager:
             S6CommandError: s6-svc exited non-zero for any other reason.
         """
         self._run_svc("-t", "restart", name)
+        _write_gateway_desired_state(name, "running")
 
     def is_running(self, name: str) -> bool:
         """True iff ``s6-svstat`` reports the service as up."""
@@ -823,15 +901,15 @@ class S6ServiceManager:
         profile: str,
         *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         """Create the s6 service directory for a profile gateway.
 
         Triggers ``s6-svscanctl -a`` so s6-svscan picks the new directory
-        up immediately. The service is created in the *up* state — to
-        register without auto-starting, follow up with ``stop(profile)``
-        (or pass the start flag via the future ``start_now=False`` arg,
-        which the Phase 4 reconciliation path uses via a ``down``
-        marker file written directly).
+        up immediately.  When *start_now* is ``True`` (the default) the
+        service starts immediately; when ``False`` a ``down`` marker file
+        is written so s6-supervise leaves the service stopped until the
+        user explicitly runs ``hermes -p <profile> gateway start``.
 
         Raises:
             ValueError: if the profile name is invalid or the service
@@ -878,6 +956,13 @@ class S6ServiceManager:
             # dirs. See ``_seed_supervise_skeleton`` for the full
             # rationale.
             _seed_supervise_skeleton(tmp_dir)
+
+            # When start_now is False, write a `down` marker so
+            # s6-supervise does not auto-start the service on rescan.
+            # Mirrors the same pattern in container_boot.py
+            # _register_gateway_slot when start=False.
+            if not start_now:
+                (tmp_dir / "down").touch()
 
             tmp_dir.rename(svc_dir)
         except Exception:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1431,6 +1431,15 @@ function Install-Venv {
     
     if (Test-Path "venv") {
         Write-Info "Virtual environment already exists, recreating..."
+        # On Windows, native Python extensions (e.g. _bcrypt.pyd) are loaded as
+        # DLLs by any running hermes process. Windows denies deletion of loaded
+        # DLLs, so kill any hermes.exe tree before removing the venv.
+        if ($env:OS -eq "Windows_NT") {
+            $myPid = $PID
+            Write-Info "Stopping any running hermes processes before recreating venv..."
+            & taskkill /F /T /IM hermes.exe /FI "PID ne $myPid" 2>$null | Out-Null
+            Start-Sleep -Milliseconds 800
+        }
         Remove-Item -Recurse -Force "venv"
     }
     

--- a/tests/cron/test_jobs_crossprocess_lock.py
+++ b/tests/cron/test_jobs_crossprocess_lock.py
@@ -1,0 +1,158 @@
+"""Regression test for the jobs.json cross-process lock.
+
+Background: ``hermes cron pause`` runs in its own process (CLI → cronjob tool →
+``pause_job`` → ``update_job`` → ``save_jobs``), entirely separate from the
+gateway process that also writes ``jobs.json`` (``mark_job_run`` /
+``advance_next_run`` / due-fast-forward). The module's ``threading.Lock`` only
+serializes writers *inside one process*, so a CLI pause issued while the gateway
+was live could be silently lost to a concurrent gateway write — the job kept
+firing even though the CLI reported "Paused".
+
+``_jobs_lock()`` closes that gap with a short-held cross-process advisory file
+lock. This test proves the lock actually excludes a *separate process*, which an
+in-process ``threading.Lock`` cannot do. It covers POSIX ``fcntl`` and Windows
+``msvcrt`` backends.
+"""
+
+import os
+import subprocess
+import sys
+import textwrap
+import time
+
+import pytest
+
+from cron import jobs
+
+
+# Repo root (parent of the ``cron`` package) so the child process can import it.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(jobs.__file__)))
+
+
+def _lock_backend_available() -> bool:
+    return jobs.fcntl is not None or jobs.msvcrt is not None
+
+
+def _try_nonblocking_lock(fd: int) -> None:
+    os.lseek(fd, 0, os.SEEK_SET)
+    if jobs.fcntl is not None:
+        jobs.fcntl.flock(fd, jobs.fcntl.LOCK_EX | jobs.fcntl.LOCK_NB)
+        return
+    if jobs.msvcrt is not None:
+        jobs.msvcrt.locking(fd, jobs.msvcrt.LK_NBLCK, 1)
+        return
+    raise AssertionError("no jobs lock backend available")
+
+
+def _unlock_probe_lock(fd: int) -> None:
+    os.lseek(fd, 0, os.SEEK_SET)
+    if jobs.fcntl is not None:
+        jobs.fcntl.flock(fd, jobs.fcntl.LOCK_UN)
+    elif jobs.msvcrt is not None:
+        jobs.msvcrt.locking(fd, jobs.msvcrt.LK_UNLCK, 1)
+
+
+@pytest.mark.skipif(not _lock_backend_available(), reason="cross-process file lock backend required")
+def test_jobs_lock_excludes_another_process(tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    output_dir = cron_dir / "output"
+    monkeypatch.setattr(jobs, "CRON_DIR", cron_dir)
+    monkeypatch.setattr(jobs, "JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr(jobs, "OUTPUT_DIR", output_dir)
+
+    ready = tmp_path / "child_holds_lock"
+    release = tmp_path / "child_may_release"
+    blocker_started = tmp_path / "blocker_started"
+    blocker_acquired = tmp_path / "blocker_acquired"
+    holder = tmp_path / "holder.py"
+    holder.write_text(
+        textwrap.dedent(
+            f"""
+            import sys, time, pathlib
+            sys.path.insert(0, {_REPO_ROOT!r})
+            from cron import jobs
+
+            jobs.CRON_DIR = pathlib.Path({str(cron_dir)!r})
+            jobs.JOBS_FILE = jobs.CRON_DIR / "jobs.json"
+            jobs.OUTPUT_DIR = jobs.CRON_DIR / "output"
+
+            with jobs._jobs_lock():
+                pathlib.Path({str(ready)!r}).write_text("1")
+                # Hold the lock until the parent signals (bounded so a wedged
+                # test can never hang CI).
+                for _ in range(1000):
+                    if pathlib.Path({str(release)!r}).exists():
+                        break
+                    time.sleep(0.01)
+            """
+        )
+    )
+
+    blocker = tmp_path / "blocker.py"
+    blocker.write_text(
+        textwrap.dedent(
+            f"""
+            import sys, pathlib
+            sys.path.insert(0, {_REPO_ROOT!r})
+            from cron import jobs
+
+            jobs.CRON_DIR = pathlib.Path({str(cron_dir)!r})
+            jobs.JOBS_FILE = jobs.CRON_DIR / "jobs.json"
+            jobs.OUTPUT_DIR = jobs.CRON_DIR / "output"
+
+            pathlib.Path({str(blocker_started)!r}).write_text("1")
+            with jobs._jobs_lock():
+                pathlib.Path({str(blocker_acquired)!r}).write_text("1")
+            """
+        )
+    )
+
+    child = subprocess.Popen([sys.executable, str(holder)])
+    blocker_child = None
+    try:
+        # Wait until the child is inside the critical section.
+        for _ in range(1000):
+            if ready.exists():
+                break
+            time.sleep(0.01)
+        assert ready.exists(), "child never acquired _jobs_lock()"
+
+        # While the child holds it, a non-blocking acquire of the SAME lock file
+        # from this process must fail. A threading.Lock could never block here.
+        lock_file = jobs._jobs_lock_file()
+        fd = os.open(str(lock_file), os.O_RDWR | os.O_CREAT)
+        try:
+            acquired = False
+            try:
+                _try_nonblocking_lock(fd)
+                acquired = True
+            except OSError:
+                pass
+            assert not acquired, "parent acquired _jobs_lock_file() while child held it"
+        finally:
+            if acquired:
+                _unlock_probe_lock(fd)
+            os.close(fd)
+
+        # A second _jobs_lock() caller in another process should block until the
+        # holder releases, rather than falling through with only a process-local
+        # threading lock.
+        blocker_child = subprocess.Popen([sys.executable, str(blocker)])
+        for _ in range(1000):
+            if blocker_started.exists():
+                break
+            time.sleep(0.01)
+        assert blocker_started.exists(), "blocker process never started"
+        time.sleep(0.05)
+        assert not blocker_acquired.exists(), "second process entered _jobs_lock() while held"
+    finally:
+        release.write_text("1")
+        child.wait(timeout=15)
+        if blocker_child is not None:
+            blocker_child.wait(timeout=15)
+
+    assert blocker_acquired.exists(), "second process did not acquire _jobs_lock() after release"
+
+    # Once the child has released, the lock is freely acquirable again.
+    with jobs._jobs_lock():
+        pass

--- a/tests/docker/test_container_restart.py
+++ b/tests/docker/test_container_restart.py
@@ -296,7 +296,8 @@ def test_live_gateway_autostarts_after_real_restart_without_manual_state_stamp(
         )
         if r.returncode == 0 and '"gateway_state"' in r.stdout:
             state = r.stdout
-            break
+            if '"running"' in state:
+                break
         time.sleep(0.5)
     assert '"running"' in state, (
         f"gateway never persisted running state pre-restart: {state!r}"

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -12,9 +12,24 @@ from gateway.channel_directory import (
     resolve_channel_name,
     format_directory_for_display,
     load_directory,
+    _apply_channel_aliases,
     _build_from_sessions,
     _build_slack,
 )
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_channel_aliases(tmp_path_factory):
+    """Point the alias overlay at a nonexistent path by default so a real
+    ~/.hermes/channel_aliases.json never leaks into directory tests. Tests
+    that exercise aliases patch CHANNEL_ALIASES_PATH themselves inside the
+    test body, which takes precedence over this outer patch."""
+    missing = tmp_path_factory.mktemp("aliases") / "none.json"
+    with patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", missing):
+        yield
 
 
 def _write_directory(tmp_path, platforms):
@@ -480,3 +495,84 @@ class TestBuildSlack:
             entries = asyncio.run(_build_slack(_make_slack_adapter({"T1": client})))
 
         assert entries == []
+
+
+class TestChannelAliases:
+    """The user-maintained alias overlay (channel_aliases.json) gives durable
+    friendly names that survive the timed directory rebuild."""
+
+    def _setup_aliases(self, tmp_path, aliases):
+        alias_file = tmp_path / "channel_aliases.json"
+        alias_file.write_text(json.dumps(aliases))
+        return patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", alias_file)
+
+    def test_alias_renames_existing_entry_on_load(self, tmp_path):
+        cache_file = _write_directory(tmp_path, {
+            "whatsapp": [{"id": "120363@g.us", "name": "120363", "type": "group"}]
+        })
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             self._setup_aliases(tmp_path, {"whatsapp": {"120363@g.us": "general"}}):
+            result = load_directory()
+            assert result["platforms"]["whatsapp"][0]["name"] == "general"
+            # And the friendly name resolves back to the JID
+            assert resolve_channel_name("whatsapp", "general") == "120363@g.us"
+            assert resolve_channel_name("whatsapp", "GENERAL") == "120363@g.us"
+
+    def test_alias_injects_undiscovered_group(self, tmp_path):
+        """A group named in the alias file but not yet seen in any session is
+        still addressable by name (pre-naming before first traffic)."""
+        cache_file = _write_directory(tmp_path, {"whatsapp": []})
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             self._setup_aliases(tmp_path, {"whatsapp": {"999@g.us": "marketing"}}):
+            assert resolve_channel_name("whatsapp", "marketing") == "999@g.us"
+            entries = load_directory()["platforms"]["whatsapp"]
+            injected = [e for e in entries if e["id"] == "999@g.us"]
+            assert injected and injected[0]["type"] == "group"
+
+    def test_no_alias_file_is_noop(self, tmp_path):
+        cache_file = _write_directory(tmp_path, {
+            "whatsapp": [{"id": "120363@g.us", "name": "120363", "type": "group"}]
+        })
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", tmp_path / "nope.json"):
+            result = load_directory()
+            assert result["platforms"]["whatsapp"][0]["name"] == "120363"
+
+    def test_corrupt_alias_file_is_ignored(self, tmp_path):
+        cache_file = _write_directory(tmp_path, {
+            "whatsapp": [{"id": "120363@g.us", "name": "120363", "type": "group"}]
+        })
+        bad = tmp_path / "channel_aliases.json"
+        bad.write_text("{not json")
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             patch("gateway.channel_directory.CHANNEL_ALIASES_PATH", bad):
+            result = load_directory()
+            assert result["platforms"]["whatsapp"][0]["name"] == "120363"
+
+    def test_alias_persists_through_rebuild(self, tmp_path, monkeypatch):
+        """build_channel_directory must bake aliases into the written file so
+        they survive the periodic regeneration, not just live reads."""
+        cache_file = tmp_path / "channel_directory.json"
+        monkeypatch.setattr("gateway.channel_directory._build_from_sessions",
+                            lambda plat: [{"id": "120363@g.us", "name": "120363",
+                                           "type": "group", "thread_id": None}]
+                            if plat == "whatsapp" else [])
+        with patch("gateway.channel_directory.DIRECTORY_PATH", cache_file), \
+             self._setup_aliases(tmp_path, {"whatsapp": {"120363@g.us": "general"}}):
+            asyncio.run(build_channel_directory({}))
+            on_disk = json.loads(cache_file.read_text())
+        names = [e["name"] for e in on_disk["platforms"]["whatsapp"]
+                 if e["id"] == "120363@g.us"]
+        assert names == ["general"]
+
+    def test_apply_aliases_handles_malformed_map(self):
+        """Non-dict alias maps and non-string aliases must not raise."""
+        platforms = {"whatsapp": [{"id": "1@g.us", "name": "1", "type": "group"}]}
+        with patch("gateway.channel_directory._load_channel_aliases",
+                   return_value={
+                       "whatsapp": "not-a-dict",
+                       "telegram": None,
+                       "signal": {"+15551234567": 123},
+                   }):
+            _apply_channel_aliases(platforms)  # should not raise
+        assert platforms["whatsapp"][0]["name"] == "1"

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -36,6 +36,10 @@ def _run_apply_profile_override(
         (hermes_root / "profiles" / active_profile).mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "hermes_constants.get_default_hermes_root",
+        lambda: hermes_root,
+    )
     if hermes_home is not None:
         monkeypatch.setenv("HERMES_HOME", hermes_home)
     else:
@@ -215,3 +219,93 @@ class TestApplyProfileOverrideHermesHomeGuard:
         assert result is not None
         assert result.endswith("coder")
         assert sys.argv == ["hermes", "--continue"]
+
+
+class TestSupervisedChildIgnoresStickyProfile:
+    """The reserved default gateway s6 slot must not follow active_profile.
+
+    Inside the Docker s6 image the ``gateway-default`` service slot runs a
+    bare ``hermes gateway run`` (no ``-p``) to mean "the root HERMES_HOME
+    profile". The run-script exports ``HERMES_S6_SUPERVISED_CHILD=1``.
+    Without a guard, ``_apply_profile_override`` would read the sticky
+    ``active_profile`` file (set by e.g. the dashboard profile switcher) and
+    redirect the reserved default gateway into that profile — producing a
+    duplicate gateway for the active profile and no real default gateway.
+    """
+
+    def test_supervised_child_does_not_follow_active_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """HERMES_S6_SUPERVISED_CHILD + active_profile=briefer must NOT redirect.
+
+        Reproduces the Docker/profile scoping bug: the supervised default
+        gateway is launched as bare ``hermes gateway run`` with
+        HERMES_HOME=/opt/data (the container root, whose parent is NOT
+        ``profiles``), and a sticky ``active_profile`` of another profile.
+        The reserved default slot must stay on the root profile.
+        """
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("briefer")
+        (hermes_root / "profiles" / "briefer").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root",
+            lambda: hermes_root,
+        )
+        # Container root HERMES_HOME: parent dir is NOT "profiles", so the
+        # #22502 guard does not short-circuit — step 2 (active_profile) runs.
+        monkeypatch.setenv("HERMES_HOME", str(hermes_root))
+        monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "run"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        assert os.environ.get("HERMES_HOME") == str(hermes_root), (
+            "Supervised default gateway must stay on the root profile, not be "
+            f"hijacked by active_profile; got {os.environ.get('HERMES_HOME')!r}"
+        )
+
+    def test_non_supervised_run_still_follows_active_profile(
+        self, tmp_path, monkeypatch
+    ):
+        """Without the sentinel, a normal `hermes gateway run` still honors
+        active_profile — the guard is scoped strictly to supervised children."""
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile="briefer",
+            argv=["hermes", "gateway", "run"],
+        )
+
+        assert result is not None
+        assert result.endswith("briefer")
+
+    def test_supervised_named_profile_flag_still_wins(self, tmp_path, monkeypatch):
+        """A supervised named-profile slot passes ``-p <name>`` explicitly;
+        that must still resolve (the sentinel guard only skips the sticky
+        active_profile fallback, never an explicit flag)."""
+        hermes_root = tmp_path / ".hermes"
+        hermes_root.mkdir(parents=True, exist_ok=True)
+        (hermes_root / "active_profile").write_text("briefer")
+        (hermes_root / "profiles" / "briefer").mkdir(parents=True, exist_ok=True)
+        (hermes_root / "profiles" / "coder").mkdir(parents=True, exist_ok=True)
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setattr(
+            "hermes_constants.get_default_hermes_root",
+            lambda: hermes_root,
+        )
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setenv("HERMES_S6_SUPERVISED_CHILD", "1")
+        monkeypatch.setattr(sys, "argv", ["hermes", "-p", "coder", "gateway", "run"])
+
+        from hermes_cli.main import _apply_profile_override
+        _apply_profile_override()
+
+        result = os.environ.get("HERMES_HOME")
+        assert result is not None
+        assert result.endswith("coder")

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -75,6 +75,10 @@ def _symlink_file_or_skip(link: Path, target: Path) -> None:
         pytest.skip(f"symlinks unavailable in test environment: {exc}")
 
 
+def _profile_wrapper_path(wrapper_dir: Path, name: str) -> Path:
+    return wrapper_dir / (f"{name}.bat" if os.name == "nt" else name)
+
+
 # ---------------------------------------------------------------------------
 # _should_exclude tests
 # ---------------------------------------------------------------------------
@@ -1077,11 +1081,11 @@ class TestProfileRestoration:
         assert (hermes_home / "profiles" / "researcher" / "config.yaml").exists()
 
         # Wrapper scripts should be created
-        assert (wrapper_dir / "coder").exists()
-        assert (wrapper_dir / "researcher").exists()
+        assert _profile_wrapper_path(wrapper_dir, "coder").exists()
+        assert _profile_wrapper_path(wrapper_dir, "researcher").exists()
 
         # Wrappers should contain the right content
-        coder_wrapper = (wrapper_dir / "coder").read_text()
+        coder_wrapper = _profile_wrapper_path(wrapper_dir, "coder").read_text()
         assert "hermes -p coder" in coder_wrapper
 
     def test_import_skips_profile_dirs_without_config(self, tmp_path, monkeypatch):
@@ -1107,8 +1111,8 @@ class TestProfileRestoration:
         run_import(args)
 
         # Only valid profile should get a wrapper
-        assert (wrapper_dir / "valid").exists()
-        assert not (wrapper_dir / "empty").exists()
+        assert _profile_wrapper_path(wrapper_dir, "valid").exists()
+        assert not _profile_wrapper_path(wrapper_dir, "empty").exists()
 
     def test_import_without_profiles_module(self, tmp_path, monkeypatch):
         """Import gracefully handles missing profiles module (fresh install)."""
@@ -1199,6 +1203,9 @@ class TestQuickSnapshot:
         (home / "config.yaml").write_text("model:\n  provider: openrouter\n")
         (home / ".env").write_text("OPENROUTER_API_KEY=test-key-123\n")
         (home / "auth.json").write_text('{"providers": {}}\n')
+        (home / "channel_aliases.json").write_text(
+            '{"whatsapp": {"120363000000000000@g.us": "general"}}\n'
+        )
         (home / "cron").mkdir()
         (home / "cron" / "jobs.json").write_text('{"jobs": []}\n')
 
@@ -1240,6 +1247,13 @@ class TestQuickSnapshot:
         from hermes_cli.backup import create_quick_snapshot
         snap_id = create_quick_snapshot(hermes_home=hermes_home)
         assert (hermes_home / "state-snapshots" / snap_id / "cron" / "jobs.json").exists()
+
+    def test_copies_channel_aliases(self, hermes_home):
+        from hermes_cli.backup import create_quick_snapshot
+        snap_id = create_quick_snapshot(hermes_home=hermes_home)
+        copied = hermes_home / "state-snapshots" / snap_id / "channel_aliases.json"
+        assert copied.exists()
+        assert "120363000000000000@g.us" in copied.read_text()
 
     def test_missing_files_skipped(self, hermes_home):
         from hermes_cli.backup import create_quick_snapshot

--- a/tests/hermes_cli/test_container_boot.py
+++ b/tests/hermes_cli/test_container_boot.py
@@ -10,6 +10,7 @@ tests/docker/test_container_restart.py.
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -25,11 +26,22 @@ from hermes_cli.container_boot import (
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _posix_s6_skeleton_or_stub(monkeypatch: pytest.MonkeyPatch) -> None:
+    if hasattr(os, "mkfifo"):
+        return
+    monkeypatch.setattr(
+        "hermes_cli.service_manager._seed_supervise_skeleton",
+        lambda _svc_dir: None,
+    )
+
+
 def _make_profile(
     hermes_home: Path,
     name: str,
     *,
     state: str | None,
+    desired_state: str | None = None,
     with_pid: bool = False,
     config: bool = True,
 ) -> Path:
@@ -40,10 +52,13 @@ def _make_profile(
         # SOUL.md is what the reconciler keys on — it's always seeded by
         # `hermes profile create`. See container_boot._render_run_script.
         (p / "SOUL.md").write_text("# fake profile\n")
-    if state is not None:
-        (p / "gateway_state.json").write_text(json.dumps({
-            "gateway_state": state, "timestamp": 1234567890,
-        }))
+    if state is not None or desired_state is not None:
+        payload: dict[str, object] = {"timestamp": 1234567890}
+        if state is not None:
+            payload["gateway_state"] = state
+        if desired_state is not None:
+            payload["desired_state"] = desired_state
+        (p / "gateway_state.json").write_text(json.dumps(payload))
     if with_pid:
         (p / "gateway.pid").write_text(json.dumps(
             {"pid": 99999, "host": "old-container"},
@@ -95,7 +110,8 @@ def test_running_profile_is_registered_and_autostarted(tmp_path: Path) -> None:
     )]
     svc = scandir / "gateway-coder"
     assert (svc / "run").exists()
-    assert (svc / "run").stat().st_mode & 0o111  # executable
+    if os.name != "nt":
+        assert (svc / "run").stat().st_mode & 0o111  # executable
     assert (svc / "type").read_text().strip() == "longrun"
     # Auto-start means no down-marker.
     assert not (svc / "down").exists()
@@ -128,6 +144,46 @@ def test_startup_failed_does_not_autostart(tmp_path: Path) -> None:
     named = _named_actions(actions)
     assert named[0].action == "registered"
     assert (scandir / "gateway-broken" / "down").exists()
+
+
+def test_desired_state_running_autostarts_even_if_runtime_failed(tmp_path: Path) -> None:
+    """Persisted operator intent wins over transient runtime failures."""
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(
+        tmp_path,
+        "resilient",
+        state="startup_failed",
+        desired_state="running",
+    )
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path, scandir=scandir, dry_run=False,
+    )
+
+    assert _named_actions(actions) == [ReconcileAction(
+        profile="resilient", prior_state="running", action="started",
+    )]
+    assert not (scandir / "gateway-resilient" / "down").exists()
+
+
+def test_desired_state_stopped_blocks_legacy_running_runtime(tmp_path: Path) -> None:
+    """Explicit stop must survive a stale legacy runtime state of running."""
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(
+        tmp_path,
+        "quiet",
+        state="running",
+        desired_state="stopped",
+    )
+
+    actions = reconcile_profile_gateways(
+        hermes_home=tmp_path, scandir=scandir, dry_run=False,
+    )
+
+    assert _named_actions(actions) == [ReconcileAction(
+        profile="quiet", prior_state="stopped", action="registered",
+    )]
+    assert (scandir / "gateway-quiet" / "down").exists()
 
 
 def test_starting_state_does_not_autostart(tmp_path: Path) -> None:
@@ -513,6 +569,7 @@ def test_legacy_gateway_run_cmd_seeds_default_running_state(
     assert not (scandir / "gateway-default" / "down").exists()
     state = json.loads((tmp_path / "gateway_state.json").read_text())
     assert state["gateway_state"] == "running"
+    assert state["desired_state"] == "running"
     assert state["migrated_from"] == "legacy-container-cmd"
 
 
@@ -663,3 +720,144 @@ def test_profiles_default_subdir_is_skipped_with_warning(
     assert any(
         "profiles/default/" in record.message for record in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Dashboard-container role detection (skip reconcile on the dashboard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "container_argv",
+    [
+        # Bare subcommand (docker run ... dashboard ...).
+        ("dashboard",),
+        ("dashboard", "--host", "127.0.0.1", "--no-open"),
+        # Through s6 /init + the main-wrapper that re-execs `hermes`.
+        ("/init", "/opt/hermes/docker/main-wrapper.sh", "dashboard"),
+        (
+            "/init",
+            "/opt/hermes/docker/main-wrapper.sh",
+            "dashboard",
+            "--host",
+            "127.0.0.1",
+            "--no-open",
+        ),
+        # Wrapper that kept the explicit `hermes` argv0.
+        ("/init", "/opt/hermes/docker/main-wrapper.sh", "hermes", "dashboard"),
+    ],
+)
+def test_is_dashboard_container_true_for_dashboard_argv(
+    container_argv: tuple[str, ...],
+) -> None:
+    """A dashboard command is detected across every wrapper prefix shape."""
+    from hermes_cli.container_boot import _is_dashboard_container
+
+    assert _is_dashboard_container(container_argv) is True
+
+
+@pytest.mark.parametrize(
+    "container_argv",
+    [
+        (),  # empty (/proc/1/cmdline unreadable) — not the dashboard
+        ("gateway", "run"),
+        ("/init", "/opt/hermes/docker/main-wrapper.sh", "gateway", "run"),
+        ("/init", "/opt/hermes/docker/main-wrapper.sh", "hermes", "gateway", "run"),
+        ("chat",),
+        # A profile literally named "dashboard" must NOT match — the token
+        # we key on is the SUBCOMMAND, and `gateway run -p dashboard` is a
+        # gateway container.
+        ("gateway", "run", "-p", "dashboard"),
+    ],
+)
+def test_is_dashboard_container_false_for_non_dashboard_argv(
+    container_argv: tuple[str, ...],
+) -> None:
+    """Gateway / other commands (and empty argv) are not the dashboard."""
+    from hermes_cli.container_boot import _is_dashboard_container
+
+    assert _is_dashboard_container(container_argv) is False
+
+
+def test_main_skips_reconcile_in_dashboard_container(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """main() must NOT reconcile when PID 1 argv is the dashboard command.
+
+    A running profile is seeded so that, if reconcile ran, it would create
+    the gateway-<profile> slot. Asserting the slot is absent proves the
+    skip is real, not just a log line.
+    """
+    from hermes_cli import container_boot
+
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(tmp_path, "worker", state="running")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("S6_PROFILE_GATEWAY_SCANDIR", str(scandir))
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: ("/init", "/opt/hermes/docker/main-wrapper.sh", "dashboard"),
+    )
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    assert not (scandir / "gateway-worker").exists()
+    assert not (scandir / "gateway-default").exists()
+    assert "skipping (dashboard container" in capsys.readouterr().out
+
+
+def test_main_reconciles_in_gateway_container(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() reconciles normally when PID 1 argv is the gateway command —
+    the dashboard skip is scoped strictly to the dashboard role."""
+    from hermes_cli import container_boot
+
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(tmp_path, "worker", state="running")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("S6_PROFILE_GATEWAY_SCANDIR", str(scandir))
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: ("/init", "/opt/hermes/docker/main-wrapper.sh", "gateway", "run"),
+    )
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    # The worker slot was registered + started (prior_state running).
+    assert (scandir / "gateway-worker").exists()
+    assert not (scandir / "gateway-worker" / "down").exists()
+
+
+def test_main_ignores_removed_skip_reconcile_env_var(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy HERMES_SKIP_PROFILE_RECONCILE flag is gone: setting it on a
+    gateway container must NOT suppress reconciliation. Role is decided by
+    PID 1 argv alone, so a stale flag in someone's manifest is inert."""
+    from hermes_cli import container_boot
+
+    scandir = tmp_path / "run-service"; scandir.mkdir()
+    _make_profile(tmp_path, "worker", state="running")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("S6_PROFILE_GATEWAY_SCANDIR", str(scandir))
+    monkeypatch.setenv("HERMES_SKIP_PROFILE_RECONCILE", "1")
+    monkeypatch.setattr(
+        container_boot,
+        "_read_container_argv",
+        lambda: ("/init", "/opt/hermes/docker/main-wrapper.sh", "gateway", "run"),
+    )
+
+    rc = container_boot.main()
+
+    assert rc == 0
+    # Reconcile still ran despite the stale env var.
+    assert (scandir / "gateway-worker").exists()

--- a/tests/hermes_cli/test_dashboard_unified_launch.py
+++ b/tests/hermes_cli/test_dashboard_unified_launch.py
@@ -57,6 +57,8 @@ class TestUnifiedDashboardRouting:
         assert opened == ["http://127.0.0.1:9119/?profile=worker_x"]
 
     def test_profile_launch_reexecs_machine_dashboard(self, main_mod, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(main_mod.sys, "platform", "linux")
         monkeypatch.setattr(
             "hermes_cli.profiles.get_active_profile_name", lambda: "worker_x"
         )
@@ -79,8 +81,47 @@ class TestUnifiedDashboardRouting:
         assert "-p" in argv and argv[argv.index("-p") + 1] == "default"
         assert "--open-profile" in argv
         assert argv[argv.index("--open-profile") + 1] == "worker_x"
-        # Profile HERMES_HOME dropped so the child binds the machine root.
-        assert "HERMES_HOME" not in env
+        # The child is pinned to the machine ROOT, not the launching profile's
+        # HERMES_HOME.  For a standard install (HERMES_HOME unset) that root is
+        # the platform-native default (~/.hermes), NOT dropped — see the Docker
+        # test below for why we resolve explicitly instead of popping.
+        from hermes_constants import get_default_hermes_root
+        assert env.get("HERMES_HOME") == str(get_default_hermes_root())
+
+    def test_reexec_pins_docker_machine_root(self, main_mod, monkeypatch):
+        """In the Docker layout (HERMES_HOME=/opt/data, profiles under
+        /opt/data/profiles/<name>) the reroute must pin the child to the
+        machine root /opt/data — NOT drop HERMES_HOME.
+
+        Dropping it makes the child fall back to $HOME/.hermes
+        (= /opt/data/.hermes), an empty auto-seeded home, so the dashboard
+        shows only the default profile and the .install_method stamp is
+        missing (which also misfires the Docker update-button guard).
+        Regression test for the support report.
+        """
+        monkeypatch.setenv("HERMES_HOME", "/opt/data/profiles/oracle")
+        monkeypatch.setattr(main_mod.sys, "platform", "linux")
+        monkeypatch.setattr(
+            "hermes_cli.profiles.get_active_profile_name", lambda: "oracle"
+        )
+        monkeypatch.setattr(main_mod, "_dashboard_listening", lambda host, port: False)
+        execs = []
+
+        def fake_exec(exe, argv, env):
+            execs.append((exe, argv, env))
+            raise SystemExit(0)
+
+        monkeypatch.setattr(main_mod.os, "execvpe", fake_exec)
+
+        with pytest.raises(SystemExit):
+            main_mod.cmd_dashboard(_args())
+
+        assert len(execs) == 1
+        _exe, _argv, env = execs[0]
+        # get_default_hermes_root() strips the trailing profiles/<name>, so the
+        # child binds /opt/data — where the real default/oracle/saga profiles
+        # and the .install_method stamp actually live.
+        assert env.get("HERMES_HOME", "").replace("\\", "/") == "/opt/data"
 
     def test_desktop_profile_backend_skips_machine_dashboard_reroute(self, main_mod, monkeypatch):
         """A desktop-spawned named-profile backend (HERMES_DESKTOP=1) must NOT

--- a/tests/hermes_cli/test_profiles_s6_hooks.py
+++ b/tests/hermes_cli/test_profiles_s6_hooks.py
@@ -54,10 +54,12 @@ class _S6Manager:
     def register_profile_gateway(
         self, profile: str, *,
         extra_env: dict[str, str] | None = None,
+        start_now: bool = True,
     ) -> None:
         if self.raise_on_register is not None:
             raise self.raise_on_register
         self.registered.append(profile)
+        self.last_start_now = start_now
 
     def unregister_profile_gateway(self, profile: str) -> None:
         if self.raise_on_unregister is not None:
@@ -105,6 +107,21 @@ def test_register_calls_through_on_s6(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     _maybe_register_gateway_service("coder")
     assert mgr.registered == ["coder"]
+
+
+def test_register_passes_start_now_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_maybe_register_gateway_service must register with start_now=False
+    so that profile creation does not auto-start a gateway that may
+    conflict with the main gateway's bot-token lock."""
+    _patch_detect_s6(monkeypatch)
+    mgr = _S6Manager()
+    monkeypatch.setattr(
+        "hermes_cli.service_manager.get_service_manager", lambda: mgr,
+    )
+    _maybe_register_gateway_service("coder")
+    assert mgr.last_start_now is False, (
+        "profile creation must not auto-start the gateway service"
+    )
 
 
 def test_register_swallows_duplicate_value_error(

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from hermes_cli.service_manager import (
@@ -69,6 +71,20 @@ def test_detect_service_manager_returns_known_value() -> None:
     assert result in ("systemd", "launchd", "windows", "s6", "none")
 
 
+def test_detect_service_manager_s6_keys_off_s6_running_not_is_container(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: Fly runs s6-overlay as PID 1 in a Firecracker microVM, which
+    is not a Docker/Podman container. Gating s6 detection on is_container() made
+    the dispatch path inert on Fly, so `hermes gateway restart` spawned a
+    foreground gateway that fought the supervised one. Detection must key off
+    s6 being PID 1 (`_s6_running`) alone."""
+    monkeypatch.setattr(
+        "hermes_cli.service_manager._s6_running", lambda: True,
+    )
+    assert detect_service_manager() == "s6"
+
+
 # ---------------------------------------------------------------------------
 # _s6_running — must work for unprivileged users, not just root
 # ---------------------------------------------------------------------------
@@ -86,8 +102,11 @@ def _patch_s6_paths(
     real_read_text = _Path.read_text
     real_is_dir = _Path.is_dir
 
+    def _norm(path: _Path) -> str:
+        return str(path).replace("\\", "/")
+
     def fake_read_text(self, *args, **kwargs):  # type: ignore[override]
-        if str(self) == "/proc/1/comm":
+        if _norm(self) == "/proc/1/comm":
             if isinstance(comm, OSError):
                 raise comm
             if comm is None:
@@ -96,7 +115,7 @@ def _patch_s6_paths(
         return real_read_text(self, *args, **kwargs)
 
     def fake_is_dir(self):  # type: ignore[override]
-        if str(self) == "/run/s6/basedir":
+        if _norm(self) == "/run/s6/basedir":
             return basedir_is_dir
         return real_is_dir(self)
 
@@ -373,10 +392,15 @@ def test_get_service_manager_returns_s6_instance(
 
 
 @pytest.fixture
-def s6_scandir(tmp_path):
+def s6_scandir(tmp_path, monkeypatch: pytest.MonkeyPatch):
     """Empty scandir for the S6ServiceManager tests."""
     d = tmp_path / "service"
     d.mkdir()
+    if not hasattr(os, "mkfifo"):
+        monkeypatch.setattr(
+            "hermes_cli.service_manager._seed_supervise_skeleton",
+            lambda _svc_dir: None,
+        )
     return d
 
 
@@ -422,6 +446,7 @@ def test_s6_manager_kind_and_supports_registration() -> None:
 # tests/docker/test_s6_profile_gateway_integration.py.
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     """Verifies the dirs + FIFO + modes the helper lays down."""
     import stat
@@ -459,6 +484,7 @@ def test_seed_supervise_skeleton_creates_expected_layout(tmp_path) -> None:
     assert stat.S_IMODE(control.stat().st_mode) == 0o660
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     """When a log/ subdir exists, its supervise tree also gets seeded.
 
@@ -489,6 +515,7 @@ def test_seed_supervise_skeleton_handles_log_subservice(tmp_path) -> None:
     assert log_control.exists() and stat.S_ISFIFO(log_control.stat().st_mode)
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_seed_supervise_skeleton_skips_when_no_log_subservice(tmp_path) -> None:
     """If log/ isn't present, no logger skeleton is created."""
     from hermes_cli.service_manager import _seed_supervise_skeleton
@@ -503,6 +530,7 @@ def test_seed_supervise_skeleton_skips_when_no_log_subservice(tmp_path) -> None:
     )
 
 
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="requires POSIX FIFO support")
 def test_seed_supervise_skeleton_is_idempotent(tmp_path) -> None:
     """Calling the helper twice on the same dir is a no-op the second time.
 
@@ -531,7 +559,8 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
 
     run_path = svc_dir / "run"
     assert run_path.is_file()
-    assert run_path.stat().st_mode & 0o111  # executable
+    if os.name != "nt":
+        assert run_path.stat().st_mode & 0o111  # executable
     run_text = run_path.read_text()
     assert "export HOME=/opt/data" in run_text
     assert "hermes -p coder gateway run" in run_text
@@ -570,6 +599,35 @@ def test_s6_register_creates_service_dir_and_triggers_scan(
         and str(s6_scandir) in cmd
         for cmd in fake_subprocess_run
     ), f"s6-svscanctl -a not invoked; saw: {fake_subprocess_run}"
+
+
+def test_s6_register_start_now_false_writes_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """When start_now=False, a `down` marker must be written so
+    s6-supervise does not auto-start the service on rescan."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder", start_now=False)
+
+    svc_dir = s6_scandir / "gateway-coder"
+    assert svc_dir.is_dir()
+    assert (svc_dir / "down").is_file(), (
+        "start_now=False must write a `down` marker file"
+    )
+
+
+def test_s6_register_start_now_true_no_down_marker(
+    s6_scandir, fake_subprocess_run,
+) -> None:
+    """When start_now=True (default), no `down` marker should exist."""
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder")
+
+    svc_dir = s6_scandir / "gateway-coder"
+    assert svc_dir.is_dir()
+    assert not (svc_dir / "down").exists(), (
+        "start_now=True must NOT write a `down` marker file"
+    )
 
 
 def test_s6_register_extra_env_is_quoted(s6_scandir, fake_subprocess_run) -> None:
@@ -681,6 +739,48 @@ def test_s6_lifecycle_dispatches_to_s6_svc(
 
     flags = [c[1] for c in fake_subprocess_run if c[0] == "s6-svc"]
     assert flags == ["-u", "-d", "-t"]
+
+
+def test_s6_lifecycle_persists_named_profile_desired_state(
+    s6_scandir,
+    fake_subprocess_run,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    hermes_home = tmp_path / "hermes-home"
+    profile_dir = hermes_home / "profiles" / "coder"
+    profile_dir.mkdir(parents=True)
+    (s6_scandir / "gateway-coder").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.start("gateway-coder")
+    assert json.loads((profile_dir / "gateway_state.json").read_text())["desired_state"] == "running"
+    mgr.stop("gateway-coder")
+    assert json.loads((profile_dir / "gateway_state.json").read_text())["desired_state"] == "stopped"
+    mgr.restart("gateway-coder")
+    assert json.loads((profile_dir / "gateway_state.json").read_text())["desired_state"] == "running"
+
+
+def test_s6_lifecycle_persists_default_profile_desired_state(
+    s6_scandir,
+    fake_subprocess_run,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import json
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    (s6_scandir / "gateway-default").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home / "profiles" / "coder"))
+
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.start("gateway-default")
+    state = json.loads((hermes_home / "gateway_state.json").read_text())
+    assert state["desired_state"] == "running"
 
 
 # ---------------------------------------------------------------------------
@@ -907,3 +1007,38 @@ def test_s6_stop_tolerates_marker_write_failure(monkeypatch, s6_scandir):
     mgr.stop("gateway-coder")  # must not raise
 
     assert any(cmd[0] == "s6-svc" and "-d" in cmd for cmd in svc_calls)
+
+
+def test_s6_log_run_chowns_gateways_parent(s6_scandir, fake_subprocess_run) -> None:
+    """The log/run script must chown the logs/gateways/ parent, not just the leaf.
+
+    Regression guard for #45258: `mkdir -p` creates the gateways/ parent
+    root-owned on a root-context boot, and a leaf-only chown leaves it that
+    way. Every profile registered later then runs its log service as the
+    dropped hermes user and s6-log crash-loops on `mkdir: Permission denied`.
+    """
+    mgr = S6ServiceManager(scandir=s6_scandir)
+    mgr.register_profile_gateway("coder")
+
+    log_text = (s6_scandir / "gateway-coder" / "log" / "run").read_text()
+
+    parent_chown = 'chown hermes:hermes "$HERMES_HOME/logs/gateways"'
+    assert parent_chown in log_text, (
+        "log/run must chown the logs/gateways parent so profiles added "
+        f"after a root-context boot can create their leaf dirs. Saw: {log_text!r}"
+    )
+    # Non-recursive on purpose: sibling profile leaf dirs are each managed
+    # by their own log/run; a recursive parent chown would race them.
+    assert 'chown -R hermes:hermes "$HERMES_HOME/logs/gateways"' not in log_text
+
+    # Ordering: mkdir creates the parent, then the parent chown repairs its
+    # ownership, then the leaf chown — all before s6-log execs.
+    mkdir_idx = log_text.index('mkdir -p "$log_dir"')
+    parent_idx = log_text.index(parent_chown)
+    leaf_idx = log_text.index('chown -R hermes:hermes "$log_dir"')
+    exec_idx = log_text.index("s6-log 1 ")
+    assert mkdir_idx < parent_idx < leaf_idx < exec_idx
+
+    # The parent path must be a runtime env expansion, never a baked-in
+    # absolute path (same contract as the log_dir itself).
+    assert '/opt/data/logs/gateways"' not in log_text

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -1,10 +1,20 @@
-"""Parser-only tests for send_message targets.
+"""Parser-only and lightweight routing tests for send_message targets.
 
 These stay separate from ``test_send_message_tool.py`` because that module
 skips wholesale when optional Telegram dependencies are not installed.
 """
 
-from tools.send_message_tool import _parse_target_ref
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from gateway.config import Platform
+from tools.send_message_tool import _parse_target_ref, send_message_tool
+
+
+def _run_async_immediately(coro):
+    return asyncio.run(coro)
 
 
 def test_photon_e164_target_is_explicit() -> None:
@@ -17,4 +27,66 @@ def test_photon_e164_target_is_explicit() -> None:
 
 def test_e164_target_still_requires_phone_platform() -> None:
     assert _parse_target_ref("matrix", "+15551234567")[2] is False
+
+
+def test_whatsapp_group_jid_target_is_explicit() -> None:
+    chat_id, thread_id, is_explicit = _parse_target_ref(
+        "whatsapp", "120363000000000000@g.us"
+    )
+
+    assert chat_id == "120363000000000000@g.us"
+    assert thread_id is None
+    assert is_explicit is True
+
+
+def test_whatsapp_native_jids_are_explicit() -> None:
+    assert _parse_target_ref("whatsapp", "15551234567@s.whatsapp.net")[2] is True
+    assert _parse_target_ref("whatsapp", "test-linked-id@lid")[2] is True
+    assert _parse_target_ref("whatsapp", "status@broadcast")[2] is True
+    assert _parse_target_ref("whatsapp", "120363000000000000@newsletter")[2] is True
+
+
+def test_whatsapp_jid_suffix_only_matches_whatsapp() -> None:
+    assert _parse_target_ref("telegram", "120363000000000000@g.us")[2] is False
+    assert _parse_target_ref("signal", "test-linked-id@lid")[2] is False
+
+
+def test_whatsapp_friendly_name_still_uses_directory_resolution() -> None:
+    assert _parse_target_ref("whatsapp", "general")[2] is False
+
+
+def test_send_message_routes_whatsapp_group_jid_without_home_fallback() -> None:
+    whatsapp_cfg = SimpleNamespace(enabled=True, token=None, extra={"api_url": "http://bridge"})
+    config = SimpleNamespace(
+        platforms={Platform.WHATSAPP: whatsapp_cfg},
+        get_home_channel=lambda _platform: SimpleNamespace(chat_id="15551234567@s.whatsapp.net"),
+    )
+
+    with patch("gateway.config.load_gateway_config", return_value=config), \
+         patch("tools.interrupt.is_interrupted", return_value=False), \
+         patch("gateway.channel_directory.resolve_channel_name", side_effect=AssertionError("raw JID should not resolve via directory")), \
+         patch("model_tools._run_async", side_effect=_run_async_immediately), \
+         patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+         patch("gateway.mirror.mirror_to_session", return_value=True):
+        result = json.loads(
+            send_message_tool(
+                {
+                    "action": "send",
+                    "target": "whatsapp:120363000000000000@g.us",
+                    "message": "hello group",
+                }
+            )
+        )
+
+    assert result["success"] is True
+    assert "note" not in result
+    send_mock.assert_awaited_once_with(
+        Platform.WHATSAPP,
+        whatsapp_cfg,
+        "120363000000000000@g.us",
+        "hello group",
+        thread_id=None,
+        media_files=[],
+        force_document=False,
+    )
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1224,6 +1224,58 @@ class TestParseTargetRefE164:
         assert _parse_target_ref("matrix", "+15551234567")[2] is False
 
 
+class TestParseTargetRefWhatsAppJID:
+    """_parse_target_ref accepts native WhatsApp JIDs as explicit targets.
+
+    Regression: group JIDs (``<id>@g.us``) and linked-identity JIDs
+    (``<id>@lid``) matched no branch and fell through to home-channel
+    resolution, so ``send_message(target="whatsapp:<group-jid>")`` silently
+    delivered to the configured home DM instead of the requested group.
+    """
+
+    def test_group_jid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "whatsapp", "120363000000000000@g.us"
+        )
+        assert chat_id == "120363000000000000@g.us"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_user_jid_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref(
+            "whatsapp", "15551234567@s.whatsapp.net"
+        )
+        assert chat_id == "15551234567@s.whatsapp.net"
+        assert is_explicit is True
+
+    def test_lid_jid_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref(
+            "whatsapp", "test-linked-id@lid"
+        )
+        assert chat_id == "test-linked-id@lid"
+        assert is_explicit is True
+
+    def test_broadcast_and_newsletter_jids_are_explicit(self):
+        assert _parse_target_ref("whatsapp", "status@broadcast")[2] is True
+        assert _parse_target_ref("whatsapp", "120363000000000000@newsletter")[2] is True
+
+    def test_whatsapp_e164_still_explicit_alongside_jids(self):
+        """The pre-existing '+'-prefixed E.164 path must keep working."""
+        chat_id, _, is_explicit = _parse_target_ref("whatsapp", "+15551234567")
+        assert chat_id == "+15551234567"
+        assert is_explicit is True
+
+    def test_jid_suffix_only_matches_whatsapp(self):
+        """WhatsApp JID suffixes must NOT be treated as explicit elsewhere."""
+        assert _parse_target_ref("telegram", "120363000000000000@g.us")[2] is False
+        assert _parse_target_ref("signal", "test-linked-id@lid")[2] is False
+
+    def test_non_jid_whatsapp_target_falls_through(self):
+        """A bare friendly name is not a JID — it must fall through to
+        directory resolution (returns not-explicit so the caller can resolve)."""
+        assert _parse_target_ref("whatsapp", "general")[2] is False
+
+
 class TestParseTargetRefSlack:
     """_parse_target_ref recognizes Slack channel/user IDs as explicit."""
 

--- a/tests/tools/test_stage2_hook_log_dir_seed.py
+++ b/tests/tools/test_stage2_hook_log_dir_seed.py
@@ -1,0 +1,60 @@
+"""Contract test: the s6-overlay stage2 hook seeds $HERMES_HOME/logs/gateways
+as the hermes user.
+
+Regression guard for #45258: the per-profile gateway log service
+(`gateway-<profile>/log/run`) creates `logs/gateways/` via `mkdir -p` but only
+chowns the leaf `logs/gateways/<profile>`. If the first log service to boot
+runs in root context, the `gateways/` parent is created root-owned and stays
+that way; every profile registered later runs its log service as the dropped
+hermes user and s6-log crash-loops on `mkdir: Permission denied`.
+
+Seeding `logs/gateways` in stage2 (cont-init runs before any service starts)
+guarantees the parent already exists hermes-owned by the time the first
+log/run executes its `mkdir -p`.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE2_HOOK = REPO_ROOT / "docker" / "stage2-hook.sh"
+
+
+@pytest.fixture(scope="module")
+def stage2_text() -> str:
+    if not STAGE2_HOOK.exists():
+        pytest.skip("docker/stage2-hook.sh not present in this checkout")
+    return STAGE2_HOOK.read_text(encoding="utf-8")
+
+
+def _seed_mkdir_block(text: str) -> str:
+    """Extract the `as_hermes mkdir -p \\ ...` seed block."""
+    m = re.search(r"as_hermes mkdir -p \\\n(?:[^\n]*\\\n)*[^\n]*\n", text)
+    assert m, "stage2-hook.sh must contain the as_hermes mkdir -p seed block"
+    return m.group(0)
+
+
+def test_logs_gateways_is_seeded(stage2_text: str) -> None:
+    block = _seed_mkdir_block(stage2_text)
+    assert '"$HERMES_HOME/logs/gateways"' in block, (
+        "logs/gateways must be seeded hermes-owned in stage2 so profiles "
+        "added after first boot can create their log dirs (#45258)"
+    )
+    # The parent must also be seeded so mkdir -p inside the block never
+    # creates logs/ implicitly with surprising ownership.
+    assert '"$HERMES_HOME/logs"' in block
+
+
+def test_logs_subtree_is_healed_when_chown_needed(stage2_text: str) -> None:
+    """The needs_chown repair loop must cover the logs subtree recursively —
+    that is what makes the seed entry above sufficient (no separate
+    logs/gateways loop entry needed)."""
+    m = re.search(r"for sub in ([^;]*); do", stage2_text)
+    assert m, "stage2-hook.sh must contain the needs_chown subdir repair loop"
+    assert "logs" in m.group(1).split(), (
+        "the needs_chown loop must recursively chown logs/ — it covers "
+        "logs/gateways, so the seed list does not need a loop twin"
+    )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -40,6 +40,14 @@ _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
 # downstream adapters (signal, etc.) expect.
 _PHONE_PLATFORMS = frozenset({"photon", "signal", "sms", "whatsapp"})
 _E164_TARGET_RE = re.compile(r"^\s*\+(\d{7,15})\s*$")
+# WhatsApp JIDs: group chats (<digits>@g.us), individual users
+# (<phone>@s.whatsapp.net), linked identities (<id>@lid), and broadcast /
+# newsletter chats. These are explicit native targets the bridge accepts
+# verbatim — they must NOT fall through to home-channel resolution.
+_WHATSAPP_JID_RE = re.compile(
+    r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
+    re.IGNORECASE,
+)
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -508,6 +516,12 @@ def _parse_target_ref(platform_name: str, target_ref: str):
     if platform_name == "email":
         match = _EMAIL_TARGET_RE.fullmatch(target_ref)
         if match:
+            return target_ref.strip(), None, True
+    if platform_name == "whatsapp":
+        # Native WhatsApp JIDs (group @g.us, user @s.whatsapp.net, @lid, etc.)
+        # are explicit targets — pass through verbatim. E.164 '+' numbers fall
+        # through to the _PHONE_PLATFORMS handler below.
+        if _WHATSAPP_JID_RE.fullmatch(target_ref):
             return target_ref.strip(), None, True
     if platform_name in _PHONE_PLATFORMS:
         match = _E164_TARGET_RE.fullmatch(target_ref)


### PR DESCRIPTION
## Summary

This PR ports selected upstream runtime, gateway, cron, Desktop, and Windows restart fixes into the fork while keeping AITuber/custom work out of this branch.

Included now:

- S6/profile gateway/dashboard restart supervision fixes.
- Windows installer venv lock fix from upstream commit `f7955137828e43d26bab926f0aacc5302d5fa357`, which stops running `hermes.exe` trees before recreating the venv so loaded native extension DLLs do not block deletion.
- WhatsApp native JID routing hardening: raw group/user/linked/broadcast/newsletter JIDs are explicit targets and no longer fall through to home-channel fallback.
- Durable `channel_aliases.json` overlay for regenerated channel directories, plus quick snapshot coverage for that alias state.
- Cron `jobs.json` cross-process write serialization so CLI pause/resume/remove cannot be silently clobbered by gateway scheduler bookkeeping.
- Curator rollback now uses the same cron cross-process lock when rewriting restored skill references.
- Desktop profile switching now resyncs `$connection` from the active profile descriptor so remote profiles attach images as bytes and file/media requests target the active backend.
- Windows-local test portability guards retained without weakening Linux S6 behavior.

## Red-team notes

- CVE-class risk area: messaging tools are execution-boundary tools. A raw `whatsapp:<group-jid>` target that falls through to the configured home DM can silently deliver agent output to the wrong chat.
- CVE-class risk area: cron is an autonomous execution boundary. A lost update in `jobs.json` can leave a job firing after the CLI reports it paused or removed.
- CVE-class risk area: Desktop remote profile switching is a machine-boundary control. A stale local `$connection` can send local paths to a remote backend or target file/media requests at the wrong machine.
- Guardrail impact: explicit native WhatsApp targets now bypass directory resolution and fallback, while friendly names still use the channel directory path.
- Scheduler impact: `jobs.json` load/modify/save critical sections now use a short-held advisory file lock across processes, with Windows `msvcrt` coverage added in this fork.
- Desktop impact: `$connection.mode` follows the active backend after profile swaps, preserving `image.attach_bytes` for remote profiles.
- Recovery impact: aliases are now included in quick state snapshots, so a restored gateway keeps the operator-defined routing names needed for safe sends.
- Personal-info hygiene: upstream release attribution mapping and personal-author metadata were intentionally not imported; this branch carries content-only commits with no personal email metadata.

## Duplicate check

- Upstream PR search for `WhatsApp group JID target home DM` did not show a separate open PR to duplicate.
- Upstream issue search for `WhatsApp group JID target home DM channel aliases` did not show a matching open issue to supersede.
- Upstream PR search for `make jobs.json writes safe across processes cron` returned no separate open PR to duplicate.
- Upstream issue search for `cron pause resume remove clobber gateway jobs.json` returned no matching open issue to supersede.
- Upstream issue #46651 is closed by the official Desktop profile-switch fix; this branch ports that content while keeping personal author metadata out of fork history.

## Validation

- PowerShell syntax parse for `scripts/install.ps1` -> OK
- `.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_service_manager.py tests\hermes_cli\test_container_boot.py tests\hermes_cli\test_apply_profile_override.py tests\hermes_cli\test_dashboard_unified_launch.py tests\tools\test_stage2_hook_log_dir_seed.py -q` -> 127 passed, 4 skipped
- `.venv\Scripts\python.exe -m pytest tests\gateway\test_channel_directory.py tests\tools\test_send_message_tool.py tests\tools\test_send_message_target_parse.py tests\hermes_cli\test_backup.py -q` -> 293 passed, 3 skipped
- `.venv\Scripts\python.exe -m pytest tests\cron\test_jobs_crossprocess_lock.py tests\cron\test_jobs.py tests\cron\test_rewrite_skill_refs.py tests\cron\test_scheduler.py tests\agent\test_curator_backup.py -q` -> 268 passed, 1 warning
- `.venv\Scripts\python.exe -m pytest tests\hermes_cli\test_cron.py tests\hermes_cli\test_cron_parser_builder.py tests\cron\test_cronjob_schema.py -q` -> 13 passed
- `npm --workspace apps/desktop exec -- vitest run src/store/profile.test.ts --environment jsdom` -> 1 file passed, 4 tests passed
- `npm --workspace apps/desktop exec -- eslint src/store/profile.ts src/store/profile.test.ts --concurrency 6` -> passed
- `npm --workspace apps/desktop run typecheck` -> passed
- `.venv\Scripts\python.exe -m ruff check gateway\channel_directory.py hermes_cli\backup.py tools\send_message_tool.py tests\gateway\test_channel_directory.py tests\tools\test_send_message_tool.py tests\tools\test_send_message_target_parse.py tests\hermes_cli\test_backup.py` -> All checks passed
- `.venv\Scripts\python.exe -m ruff check cron\jobs.py agent\curator_backup.py tests\cron\test_jobs_crossprocess_lock.py` -> All checks passed
- `.venv\Scripts\python.exe -m ruff check ...` on the restart touched files -> All checks passed
- `git diff --check` / staged diff check -> clean
- Commit diff secret/personal-email scan -> no real-secret or personal-email patterns found; only synthetic WhatsApp JIDs, decorators, and test fixture env keys were present.

## Security/runtime report

`C:\tmp\codex-security-scans\hermes-agent\b1f5fa80a_s6_desktop_windows_restart_20260615T2225Z\report.md`