### PR TITLE
fix(security): harden credential reads, request dumps, and URL DNS checks

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1221,12 +1221,19 @@ def dump_api_request_debug(
 
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S_%f")
         dump_file = agent.logs_dir / f"request_dump_{agent.session_id}_{timestamp}.json"
-        atomic_json_write(dump_file, dump_payload, default=str)
+        # Redact secrets before persisting or printing. Request dumps include
+        # the full prompt/tool payload and provider error bodies, so failures
+        # must not leave context-embedded credentials in cleartext on disk.
+        from agent.redact import redact_sensitive_text
+
+        serialized = json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str)
+        redacted_payload = json.loads(redact_sensitive_text(serialized, force=True))
+        atomic_json_write(dump_file, redacted_payload, default=str)
 
         agent._vprint(f"{agent.log_prefix}🧾 Request debug dump written to: {dump_file}")
 
         if env_var_enabled("HERMES_DUMP_REQUEST_STDOUT"):
-            print(json.dumps(dump_payload, ensure_ascii=False, indent=2, default=str))
+            print(json.dumps(redacted_payload, ensure_ascii=False, indent=2, default=str))
 
         return dump_file
     except Exception as dump_error:

--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -263,6 +263,20 @@ def get_read_block_error(path: str) -> Optional[str]:
         except Exception:
             continue
 
+    # Sibling profiles under <root>/profiles/ have their own credential
+    # stores. A session in one profile must not be able to read another
+    # profile's auth.json, OAuth cache, webhook secrets, or MCP tokens.
+    try:
+        profiles_dir = _hermes_root_path().resolve() / "profiles"
+        if profiles_dir.is_dir():
+            for child in profiles_dir.iterdir():
+                if child.is_dir():
+                    real = child.resolve()
+                    if real not in hermes_dirs:
+                        hermes_dirs.append(real)
+    except Exception:
+        pass
+
     # Skills .hub: prompt-injection carriers.
     for hd in hermes_dirs:
         blocked_dirs = [

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -104,6 +104,7 @@ _PREFIX_PATTERNS = [
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
+    r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/tests/agent/test_file_safety_credentials.py
+++ b/tests/agent/test_file_safety_credentials.py
@@ -536,3 +536,56 @@ def test_profile_mode_blocks_root_credentials(tmp_path, monkeypatch):
     root_tok.parent.mkdir(parents=True, exist_ok=True)
     root_tok.write_text("x")
     assert "MCP token" in (get_read_block_error(str(root_tok)) or "")
+
+
+def test_sibling_profile_credentials_blocked(tmp_path, monkeypatch):
+    """Credential stores in sibling profiles must also be blocked."""
+    import agent.file_safety as fs
+
+    root = tmp_path / "hermes"
+    active = root / "profiles" / "active"
+    sibling = root / "profiles" / "sibling"
+    active.mkdir(parents=True)
+    sibling.mkdir(parents=True)
+    monkeypatch.setattr(fs, "_hermes_home_path", lambda: active)
+    monkeypatch.setattr(fs, "_hermes_root_path", lambda: root)
+
+    from agent.file_safety import get_read_block_error
+
+    sibling_auth = sibling / "auth.json"
+    sibling_auth.write_text('{"token": "dummy_sibling_secret"}')
+    err = get_read_block_error(str(sibling_auth))
+    assert err is not None
+    assert "credential store" in err
+    assert "dummy_sibling_secret" not in err
+
+    sibling_oauth = sibling / ".anthropic_oauth.json"
+    sibling_oauth.write_text('{"key": "dummy_sibling_oauth"}')
+    err = get_read_block_error(str(sibling_oauth))
+    assert err is not None
+    assert "credential store" in err
+
+    sibling_mcp = sibling / "mcp-tokens"
+    sibling_mcp.mkdir()
+    (sibling_mcp / "token.json").write_text("dummy_token")
+    err = get_read_block_error(str(sibling_mcp))
+    assert err is not None
+    assert "MCP token" in err
+
+    sibling_webhook = sibling / "webhook_subscriptions.json"
+    sibling_webhook.write_text("{}")
+    err = get_read_block_error(str(sibling_webhook))
+    assert err is not None
+    assert "credential store" in err
+
+    sibling_readme = sibling / "README.md"
+    sibling_readme.write_text("# sibling")
+    assert get_read_block_error(str(sibling_readme)) is None
+
+    third = root / "profiles" / "third"
+    third.mkdir(parents=True)
+    third_auth = third / "auth.json"
+    third_auth.write_text('{"token": "dummy_third_secret"}')
+    err = get_read_block_error(str(third_auth))
+    assert err is not None
+    assert "credential store" in err

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -53,6 +53,10 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("fal_abc123def456ghi789jkl")
         assert "abc123def456" not in result
 
+    def test_notion_internal_integration_token(self):
+        result = redact_sensitive_text("ntn_abc123def456ghi789jkl")
+        assert "abc123def456" not in result
+
     def test_short_token_fully_masked(self):
         result = redact_sensitive_text("key=sk-short1234567")
         assert "***" in result

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1913,6 +1913,58 @@ def test_dump_api_request_debug_uses_chat_completions_url(monkeypatch, tmp_path)
     assert payload["request"]["url"] == "http://127.0.0.1:9208/v1/chat/completions"
 
 
+def test_dump_api_request_debug_redacts_request_and_error_secrets(monkeypatch, tmp_path, capsys):
+    """Request debug dumps should redact secrets before disk/stdout output."""
+    import json
+
+    _patch_agent_bootstrap(monkeypatch)
+    monkeypatch.setenv("HERMES_DUMP_REQUEST_STDOUT", "1")
+    agent = run_agent.AIAgent(
+        model="gpt-4o",
+        base_url="http://127.0.0.1:9208/v1",
+        api_key="provider-dummy-token-1234567890",
+        quiet_mode=True,
+        max_iterations=1,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.logs_dir = tmp_path
+
+    notion_token = "ntn_abc123def456ghi789jkl"
+    error_secret = "ntn_errorsecret1234567890"
+    response_secret = "ntn_responsesecret1234567890"
+    response = SimpleNamespace(status_code=400, text=f"provider echoed {response_secret}")
+
+    class ProviderError(RuntimeError):
+        body: object
+        response: object
+
+    error = ProviderError(f"bad token {error_secret}")
+    error.body = {"message": f"bad token {error_secret}"}
+    error.response = response
+
+    dump_file = agent._dump_api_request_debug(
+        {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": f"use {notion_token}"}],
+            "metadata": {"NOTION_API_KEY": notion_token},
+        },
+        reason="provider_error",
+        error=error,
+    )
+
+    assert dump_file is not None
+    dumped_text = dump_file.read_text()
+    stdout_text = capsys.readouterr().out
+    for raw in (notion_token, error_secret, response_secret, "provider-dummy-token-1234567890"):
+        assert raw not in dumped_text
+        assert raw not in stdout_text
+
+    payload = json.loads(dumped_text)
+    assert payload["request"]["headers"]["Authorization"].startswith("Bearer provider...")
+    assert "***" in dumped_text or "..." in dumped_text
+
+
 # --- Reasoning-only response tests (fix for empty content retry loop) ---
 
 

--- a/tests/tools/test_url_safety.py
+++ b/tests/tools/test_url_safety.py
@@ -1,5 +1,6 @@
 """Tests for SSRF protection in url_safety module."""
 
+import asyncio
 import socket
 from unittest.mock import patch
 
@@ -224,7 +225,7 @@ class TestIsSafeUrl:
 
 
 class TestAsyncIsSafeUrl:
-    """async_is_safe_url must match is_safe_url (runs DNS in a thread pool)."""
+    """async_is_safe_url must match is_safe_url without unbounded DNS waits."""
 
     @pytest.mark.asyncio
     async def test_public_url_allowed(self):
@@ -239,6 +240,17 @@ class TestAsyncIsSafeUrl:
             (2, 1, 6, "", ("127.0.0.1", 0)),
         ]):
             assert await async_is_safe_url("http://localhost:8080/") is False
+
+    @pytest.mark.asyncio
+    async def test_dns_timeout_fails_closed(self, monkeypatch):
+        async def never_returns(*_args, **_kwargs):
+            await asyncio.sleep(60)
+            return True
+
+        monkeypatch.setattr("tools.url_safety._DNS_RESOLUTION_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr("tools.url_safety.asyncio.to_thread", never_returns)
+
+        assert await async_is_safe_url("https://slow-dns.example/") is False
 
 
 class TestIsBlockedIp:

--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -34,6 +34,8 @@ from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
+_DNS_RESOLUTION_TIMEOUT_SECONDS = 5.0
+
 
 def normalize_url_for_request(url: str) -> str:
     """Return an ASCII-safe HTTP URL for Hermes-owned URL tools.
@@ -394,9 +396,22 @@ def is_safe_url(url: str) -> bool:
 
 
 async def async_is_safe_url(url: str) -> bool:
-    """Same rules as :func:`is_safe_url`, but run the DNS work off the event loop.
+    """Same rules as :func:`is_safe_url`, but bound DNS waits off the event loop.
 
     ``socket.getaddrinfo`` can block; call this from async code paths (gateway,
     ``web_extract_tool``, vision download hooks) instead of ``is_safe_url``.
     """
-    return await asyncio.to_thread(is_safe_url, url)
+    try:
+        return await asyncio.wait_for(
+            asyncio.to_thread(is_safe_url, url),
+            timeout=_DNS_RESOLUTION_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Blocked request - DNS resolution timed out during URL safety check: %s",
+            url,
+        )
+        return False
+    except Exception as exc:
+        logger.warning("Blocked request - async URL safety check error for %s: %s", url, exc)
+        return False

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -102,15 +102,39 @@ from tools.tool_backend_helpers import (  # noqa: F401
     nous_tool_gateway_unavailable_message,
     prefers_gateway,
 )
-from tools.url_safety import is_safe_url, normalize_url_for_request
+from tools.url_safety import (
+    _DNS_RESOLUTION_TIMEOUT_SECONDS as _URL_SAFETY_DNS_TIMEOUT_SECONDS,
+    async_is_safe_url as _bounded_async_is_safe_url,
+    is_safe_url as _url_safety_is_safe_url,
+    normalize_url_for_request,
+)
 import sys
 
 logger = logging.getLogger(__name__)
 
+# Public compatibility name: tests and provider shims monkeypatch
+# ``tools.web_tools.is_safe_url`` directly.
+is_safe_url = _url_safety_is_safe_url
+
 
 async def async_is_safe_url(url: str) -> bool:
-    """Async wrapper around the module-level URL-safety oracle."""
-    return await asyncio.to_thread(is_safe_url, url)
+    """Async wrapper around the bounded URL-safety oracle."""
+    if is_safe_url is not _url_safety_is_safe_url:
+        try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(is_safe_url, url),
+                timeout=_URL_SAFETY_DNS_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Blocked request - web URL safety check timed out: %s",
+                url,
+            )
+            return False
+        except Exception as exc:
+            logger.warning("Blocked request - web URL safety check error for %s: %s", url, exc)
+            return False
+    return await _bounded_async_is_safe_url(url)
 
 
 # ─── Backend Selection ────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary

This PR carries three security hardening fixes while keeping fork-local personal metadata and secrets out of the diff:

1. `read_file` credential boundary hardening for sibling Hermes profiles under `<root>/profiles/*`.
2. API request debug dump redaction before disk/stdout output, including Notion internal integration token prefix coverage.
3. Bounded async URL-safety DNS waits so gateway/web/vision async paths fail closed instead of waiting indefinitely on blocking resolver work.

The first item applies the official upstream fix from NousResearch/hermes-agent#46417 for NousResearch/hermes-agent#46411. The second item applies the security content from upstream commits `ad58dd51a` and `aab2e99ba` while intentionally omitting the release author-map personal email addition. The third item addresses the red-team DNS timeout finding found during this fork sync; duplicate issue/PR search found no matching open upstream item.

## Provenance and privacy

- Source PR: https://github.com/NousResearch/hermes-agent/pull/46417
- Source commits: `ad58dd51a`, `aab2e99ba`
- Red-team follow-up: async URL safety DNS timeout/fail-closed hardening in `tools/url_safety.py` and `tools/web_tools.py`.
- Applied manually as fork-local security sync commits using noreply author and committer metadata.
- No secrets, environment variable values, local credential files, or personal author email metadata are included.
- Duplicate searches:
  - `read_file credential sibling profile`: no open matching PRs found.
  - `request_dump redact_sensitive_text request debug dump secrets`: no open matching PRs found.
  - `url_safety getaddrinfo timeout DNS async_is_safe_url`: no open matching PRs found.

## Validation

- `.venv\Scripts\python.exe -m pytest tests\agent\test_file_safety_credentials.py tests\agent\test_redact.py -q` -> 114 passed, 1 skipped
- `.venv\Scripts\python.exe -m pytest tests\run_agent\test_run_agent_codex_responses.py -q` -> 77 passed, 1 warning
- `.venv\Scripts\python.exe -m pytest tests\tools\test_url_safety.py tests\tools\test_vision_tools.py tests\tools\test_web_tools_config.py tests\tools\test_website_policy.py -q` -> 274 passed, 1 warning
- `.venv\Scripts\python.exe -m ruff check tools\url_safety.py tools\web_tools.py tests\tools\test_url_safety.py` -> All checks passed
- `git diff --check` -> no diff errors, line-ending warnings only
- Diff secret/personal-email scan -> no real-secret or personal-email patterns found

## Security report

`C:\tmp\codex-security-scans\hermes-agent\06ea2034be_security_profile_and_debug_dump_20260615T2158Z\report.md`
