### PR TITLE
[codex] fix CI fallout from security dependency patch

### DIFF
--- a/plugins/ai-employee-org/stack.py
+++ b/plugins/ai-employee-org/stack.py
@@ -95,7 +95,14 @@ def apply_stack_via_script(*, dry_run: bool = False) -> dict[str, Any]:
     ]
     if dry_run:
         cmd.append("--dry-run")
-    proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        stdin=subprocess.DEVNULL,
+    )
     return {
         "ok": proc.returncode == 0,
         "stdout": proc.stdout.strip()[:500],

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -2153,7 +2153,7 @@ class TestRunJobWakeGate:
         import cron.scheduler as scheduler
 
         call_count = 0
-        def _script_stub(path):
+        def _script_stub(path, **kwargs):
             nonlocal call_count
             call_count += 1
             return (True, "regular output")

--- a/tests/scripts/test_check_galaxy_aituber_onair.py
+++ b/tests/scripts/test_check_galaxy_aituber_onair.py
@@ -5,11 +5,19 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 from pathlib import Path
+
+import pytest
 
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "windows" / "check-galaxy-aituber-onair.ps1"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32",
+    reason="Galaxy AITuber OnAir helper tests exercise Windows PowerShell and .cmd shims.",
+)
 
 
 def _extract_json(output: str) -> dict:

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -182,8 +182,8 @@ LAZY_DEPS: dict[str, tuple[str, ...]] = {
     "tool.dashboard": (
         "fastapi==0.133.1",
         "uvicorn[standard]==0.41.0",
-        "starlette==1.0.1",  # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
-        "python-multipart==0.0.27",  # FastAPI UploadFile/Form for streaming uploads (NS-501)
+        "starlette==1.3.1",  # CVE-2026-48710 (BadHost) — keep lazy-install in sync with pyproject [web]
+        "python-multipart==0.0.32",  # FastAPI UploadFile/Form for streaming uploads (NS-501)
     ),
     # Vision image-resize recovery (Pillow). Pillow is now a CORE dependency
     # (pyproject `dependencies`), so this entry is a belt-and-suspenders fallback


### PR DESCRIPTION
## Summary
- make the Windows-only Galaxy AITuber helper tests skip on non-Windows runners
- keep dashboard lazy dependency pins aligned with pyproject security pins
- update the scheduler wake-gate test stub for the current job-aware script runner contract
- set stdin=DEVNULL for the AI employee stack fallback subprocess

## Root cause
The dependency security patch moved CI past the stale uv.lock failure, then exposed four test-contract issues: Linux runners tried to execute a Windows PowerShell/.cmd test, lazy_deps still had older dashboard pins, one scheduler test mock did not accept the new job keyword argument, and one subprocess call omitted explicit stdin.

## Validation
- uv lock --check
- uv sync --locked --python 3.11 --extra all --extra dev
- python -m pytest tests/tools/test_subprocess_stdin_guard.py -q
- python -m pytest tests/cron/test_scheduler.py::TestRunJobWakeGate::test_script_runs_only_once_on_wake -q
- python -m pytest tests/test_project_metadata.py::test_pyproject_pins_match_lazy_deps_pins -q
- python -m pytest tests/scripts/test_check_galaxy_aituber_onair.py -q
- python -m pytest tests/cron/test_scheduler.py -q
- python -m pytest tests/test_project_metadata.py -q