### PR TITLE
fix(desktop): guard main-process stdio pipes

### DIFF
--- a/apps/desktop/electron/main.cjs
+++ b/apps/desktop/electron/main.cjs
@@ -1,3 +1,7 @@
+const { installStdioPipeErrorGuards } = require('./stdio-guards.cjs')
+
+installStdioPipeErrorGuards()
+
 const {
   app,
   BrowserWindow,
@@ -922,13 +926,13 @@ function openExternalUrl(rawUrl) {
 
   if (IS_WSL) {
     rememberLog(`[link] opening via WSL→Windows: ${url}`)
-    const proc = spawn('cmd.exe', ['/c', 'start', '""', url], {
+    const proc = spawn('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', 'Start-Process -FilePath $args[0]', url], {
       detached: true,
       stdio: 'ignore',
       windowsHide: true
     })
     proc.on('error', error => {
-      rememberLog(`[link] cmd.exe start failed: ${error.message}; falling back to xdg-open`)
+      rememberLog(`[link] PowerShell Start-Process failed: ${error.message}; falling back to xdg-open`)
       shell.openExternal(url).catch(fallback => rememberLog(`[link] xdg-open failed: ${fallback.message}`))
     })
     proc.unref()

--- a/apps/desktop/electron/stdio-guards.cjs
+++ b/apps/desktop/electron/stdio-guards.cjs
@@ -1,0 +1,40 @@
+'use strict'
+
+const INSTALLED_PIPE_GUARD = Symbol.for('hermes.desktop.stdioPipeGuardInstalled')
+
+function isIgnorablePipeError(error) {
+  if (!error) return false
+
+  const code = error.code || error.errno
+  if (code === 'EPIPE' || code === 'ERR_STREAM_DESTROYED') return true
+
+  return typeof error.message === 'string' && /\b(?:broken pipe|EPIPE|ERR_STREAM_DESTROYED)\b/i.test(error.message)
+}
+
+function attachPipeGuard(stream) {
+  if (!stream || typeof stream.on !== 'function') return false
+  if (stream[INSTALLED_PIPE_GUARD]) return false
+
+  const handler = error => {
+    if (isIgnorablePipeError(error)) return
+    throw error
+  }
+
+  Object.defineProperty(stream, INSTALLED_PIPE_GUARD, {
+    configurable: false,
+    enumerable: false,
+    value: true
+  })
+  stream.on('error', handler)
+
+  return true
+}
+
+function installStdioPipeErrorGuards({ stdout = process.stdout, stderr = process.stderr } = {}) {
+  return [stdout, stderr].filter(attachPipeGuard).length
+}
+
+module.exports = {
+  installStdioPipeErrorGuards,
+  isIgnorablePipeError
+}

--- a/apps/desktop/electron/stdio-guards.test.cjs
+++ b/apps/desktop/electron/stdio-guards.test.cjs
@@ -1,0 +1,71 @@
+'use strict'
+
+const assert = require('node:assert/strict')
+const { EventEmitter } = require('node:events')
+const fs = require('node:fs')
+const path = require('node:path')
+const test = require('node:test')
+
+const { installStdioPipeErrorGuards, isIgnorablePipeError } = require('./stdio-guards.cjs')
+
+function codedError(code, message = code) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}
+
+test('stdio pipe guard classifies closed-pipe write errors as ignorable', () => {
+  assert.equal(isIgnorablePipeError(codedError('EPIPE', 'broken pipe, write')), true)
+  assert.equal(isIgnorablePipeError(codedError('ERR_STREAM_DESTROYED', 'Cannot call write after destroy')), true)
+  assert.equal(isIgnorablePipeError(new Error('write EPIPE')), true)
+  assert.equal(isIgnorablePipeError(codedError('EACCES', 'permission denied')), false)
+  assert.equal(isIgnorablePipeError(null), false)
+})
+
+test('stdio pipe guard suppresses EPIPE from closed inherited stdio', () => {
+  const stdout = new EventEmitter()
+  const stderr = new EventEmitter()
+
+  assert.equal(installStdioPipeErrorGuards({ stdout, stderr }), 2)
+  assert.doesNotThrow(() => stderr.emit('error', codedError('EPIPE', 'broken pipe, write')))
+  assert.doesNotThrow(() => stdout.emit('error', codedError('ERR_STREAM_DESTROYED')))
+})
+
+test('stdio pipe guard preserves non-pipe stream errors', () => {
+  const stderr = new EventEmitter()
+
+  installStdioPipeErrorGuards({ stdout: null, stderr })
+
+  assert.throws(() => stderr.emit('error', codedError('EACCES', 'permission denied')), /permission denied/)
+})
+
+test('stdio pipe guard installs at most once per stream', () => {
+  const stdout = new EventEmitter()
+
+  assert.equal(installStdioPipeErrorGuards({ stdout, stderr: null }), 1)
+  assert.equal(installStdioPipeErrorGuards({ stdout, stderr: null }), 0)
+  assert.equal(stdout.listenerCount('error'), 1)
+})
+
+test('Electron main installs stdio guards before loading electron', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8')
+  const guardImport = source.indexOf("require('./stdio-guards.cjs')")
+  const guardInstall = source.indexOf('installStdioPipeErrorGuards()')
+  const electronImport = source.indexOf("require('electron')")
+
+  assert.notEqual(guardImport, -1)
+  assert.notEqual(guardInstall, -1)
+  assert.notEqual(electronImport, -1)
+  assert.ok(guardImport < electronImport, 'stdio guard module must load before electron')
+  assert.ok(guardInstall < electronImport, 'stdio guards must install before electron initializes')
+})
+
+test('WSL external links avoid cmd.exe command-shell URL parsing', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'main.cjs'), 'utf8')
+  const opener = source.slice(source.indexOf('if (IS_WSL)'), source.indexOf('shell.openExternal(url)'))
+
+  assert.match(opener, /spawn\('powershell\.exe'/)
+  assert.match(opener, /Start-Process -FilePath \$args\[0\]/)
+  assert.doesNotMatch(opener, /cmd\.exe/)
+  assert.doesNotMatch(opener, /'\/c'/)
+})

--- a/apps/desktop/electron/windows-child-process.test.cjs
+++ b/apps/desktop/electron/windows-child-process.test.cjs
@@ -46,7 +46,7 @@ test('intentional or interactive desktop child processes stay documented', () =>
   assert.match(source, /'--repair', '--branch'/)
   assert.match(source, /'--update', '--branch'/)
   assert.match(source, /nodePty\.spawn\(command, args/)
-  assert.match(source, /spawn\('cmd\.exe', \['\/c', 'start'/)
+  assert.match(source, /spawn\('powershell\.exe', \['-NoProfile', '-NonInteractive', '-Command', 'Start-Process -FilePath \$args\[0\]'/)
 })
 
 test('bootstrap PowerShell runner hides Windows console children', () => {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -37,7 +37,7 @@
     "test:desktop:nsis": "node scripts/test-desktop.mjs nsis",
     "test:desktop:existing": "node scripts/test-desktop.mjs existing",
     "test:desktop:fresh": "node scripts/test-desktop.mjs fresh",
-    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/link-title-window.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
+    "test:desktop:platforms": "node --test electron/bootstrap-platform.test.cjs electron/hardening.test.cjs electron/backend-env.test.cjs electron/backend-probes.test.cjs electron/bootstrap-runner.test.cjs electron/connection-config.test.cjs electron/dashboard-token.test.cjs electron/gateway-ws-probe.test.cjs electron/oauth-net-request.test.cjs electron/desktop-uninstall.test.cjs electron/session-windows.test.cjs electron/link-title-window.test.cjs electron/workspace-cwd.test.cjs electron/fs-read-dir.test.cjs electron/git-root.test.cjs electron/stdio-guards.test.cjs electron/windows-child-process.test.cjs electron/update-remote.test.cjs electron/update-rebuild.test.cjs electron/windows-user-env.test.cjs",
     "typecheck": "tsc -p . --noEmit",
     "lint": "eslint src/ electron/",
     "lint:fix": "eslint src/ electron/ --fix",
@@ -117,7 +117,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^10.0.3",
     "cross-env": "^10.1.0",
-    "electron": "40.10.2",
+    "electron": "40.10.4",
     "electron-builder": "^26.8.1",
     "eslint": "^9.39.4",
     "eslint-plugin-perfectionist": "^5.9.0",
@@ -134,7 +134,7 @@
     "wait-on": "^9.0.10"
   },
   "build": {
-    "electronVersion": "40.10.2",
+    "electronVersion": "40.10.4",
     "appId": "com.nousresearch.hermes",
     "productName": "Hermes",
     "executableName": "Hermes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.15.1",
+      "version": "0.17.0",
       "dependencies": {
         "@assistant-ui/react": "^0.12.28",
         "@assistant-ui/react-streamdown": "^0.1.11",
@@ -131,7 +131,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "concurrently": "^10.0.3",
         "cross-env": "^10.1.0",
-        "electron": "40.10.2",
+        "electron": "40.10.4",
         "electron-builder": "^26.8.1",
         "eslint": "^9.39.4",
         "eslint-plugin-perfectionist": "^5.9.0",
@@ -149,28 +149,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "apps/desktop/node_modules/@electron/get": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
-      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "env-paths": "^2.2.0",
-        "fs-extra": "^8.1.0",
-        "got": "^11.8.5",
-        "progress": "^2.0.3",
-        "semver": "^6.2.0",
-        "sumchecker": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "global-agent": "^3.0.0"
       }
     },
     "apps/desktop/node_modules/@icons-pack/react-simple-icons": {
@@ -223,80 +201,6 @@
         "three": {
           "optional": true
         }
-      }
-    },
-    "apps/desktop/node_modules/electron": {
-      "version": "40.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.2.tgz",
-      "integrity": "sha512-Xj3Hy0Imbu4g0gDIW55w/jJYz94nMO2JRSGYA3LyAn5SwaERCelgZrA21vfH+Bi//SWAWQXddHsMwCqauyMT8g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
-      },
-      "bin": {
-        "electron": "cli.js"
-      },
-      "engines": {
-        "node": ">= 12.20.55"
-      }
-    },
-    "apps/desktop/node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/desktop/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "apps/desktop/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "apps/desktop/node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "apps/desktop/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "apps/shared": {
@@ -1040,6 +944,16 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.3.tgz",
+      "integrity": "sha512-OjKpjB7gohtEjZiq6nDx1egqjZJhGPN1iFOIED+NFhB/MMkXw/XRcHjh1DGXKT5z2W9eW7Jy2UKU3gpjvusFTQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/@electron/asar": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
@@ -1174,6 +1088,38 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^3.0.0",
+        "graceful-fs": "^4.2.11",
+        "progress": "^2.0.3",
+        "semver": "^7.6.3",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "optionalDependencies": {
+        "undici": "^7.24.4"
+      }
+    },
+    "node_modules/@electron/get/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@electron/notarize": {
@@ -5802,17 +5748,6 @@
       "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.61.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
@@ -8830,6 +8765,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/electron": {
+      "version": "40.10.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.4.tgz",
+      "integrity": "sha512-ouNZrXXmdPL/wiTQ+xzXpb7B/BHg+j7XARig0SE7azFO3bjbYUd6lFjIAAiDQ02Pl/Oj7MUk+4C0hdf9yFtA1A==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 22.12.0"
+      }
+    },
     "node_modules/electron-builder": {
       "version": "26.15.3",
       "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
@@ -9192,6 +9146,19 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/environment": {
@@ -9969,27 +9936,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -14528,13 +14474,6 @@
         "url": "https://github.com/sponsors/jet2jet"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -18466,19 +18405,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
-      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
## Summary
- Install Electron main-process stdio pipe guards before `require('electron')`, suppressing only closed-pipe write failures such as `EPIPE` and `ERR_STREAM_DESTROYED` while preserving real stream errors.
- Replace the WSL external-link handoff from `cmd.exe /c start` with argument-safe PowerShell `Start-Process -FilePath $args[0]`.
- Update desktop Electron from `40.10.2` to `40.10.4`, sync `build.electronVersion`, and add focused regression coverage to the desktop platform test suite.

## Scope
This PR intentionally excludes `_docs`, `.omo` evidence, local media artifacts, and fork-specific feature work. The branch is one commit over `origin/main`. It is not opened directly against `upstream/main` because this fork is currently 393 commits ahead of upstream; an upstream PR should rebase or cherry-pick this isolated commit first.

## Review notes
Parallel review did not find an existing direct duplicate for the Electron `EPIPE: broken pipe, write` desktop crash. Broader desktop/security issues still exist and should be split into follow-up PRs instead of being mixed here: JSON-RPC method authorization, preview-webview navigation hardening, link-title SSRF handling, destructive IPC capability checks, and session/media/PTI ownership boundaries.

## Verification
- `npm --workspace apps/desktop run build`
- `node --test apps/desktop/electron/stdio-guards.test.cjs apps/desktop/electron/windows-child-process.test.cjs`
- `npm --workspace apps/desktop run test:desktop:platforms` with 200 tests, 198 passing, 2 skipped
- `npm audit --workspace apps/desktop --audit-level=moderate`
- `git diff --check`
- Source desktop launch via `scripts/windows/start-hermes-desktop.ps1`; observed `HERMES_DASHBOARD_READY port=65054`, `GET /api/status` returned 200, and desktop logs contained no `EPIPE`, `broken pipe`, `browser_init`, or uncaught-exception pipe matches.
