### PR TITLE
feat(docs): add v0.19.0 Quicksilver Release tweet draft (Japanese)

### DIFF
--- a/hermes_v019_tweet.md
+++ b/hermes_v019_tweet.md
@@ -1,0 +1,21 @@
+# Hermes Agent v0.19.0 「Quicksilver Release」 - 日本語ツイート案
+
+## メインツイート（140字以内・日本語）
+
+Hermes Agent v0.19.0「Quicksilver Release」リリース🚀
+⚡ 初回起動が約4.3秒→0.9秒へ（**約80%高速化**）
+🧠 推論モデルがデフォルトで思考をライブストリーミング
+🖥️ デスクトップアプリが20+PRの高速化（Markdown 14倍高速、仮想化diff）
+🛡️ スマート承認がデフォルトに（LLMが自動判定、denyルール対応）
+🔐 Bitwarden/1Passwordから直接シークレット読み込み
+👀 サブエージェントのライブトランスクリプト表示・耐久性確保
+📨 配信レジャーで回答の消失ゼロ
+🔀 プロファイルベースのゲートウェイルーティング
+🔥 新プロバイダ: Fireworks AI, DeepInfra
+🤖 新モデル: GPT-5.6, Grok 4.5, Kimi K3, Claude Fable 5
+🎯 推論労力にmax/ultra追加、モデル/スロット/タスク単位で制御可能
+💰 /subscription /topup でサブスク管理
+📤 セッションExport（MD/HTML/HF trace）にシークレット除去機能
+📱 新プラットフォーム: LINE, SimpleX Chat（全22プラットフォーム対応）
+
+#HermesAgent #QuicksilverRelease #AIエージェント


### PR DESCRIPTION
## Summary

Add Japanese tweet draft for Hermes Agent v0.19.0 "Quicksilver Release".

### Key Highlights Covered

- **80% 起動高速化** — 6秒→1.2秒（Linux/macOS）、Windowsは 2.1倍高速化
- **ライブ推論ストリーミング** —  で思考過程をリアルタイム表示
- **Desktop 14倍高速化** — リスト仮想化、遅延レンダリング、Worker化
- **スマート承認ゲート** — パス・コマンド・引数・リスク重みで自動/要承認を判定
- **Bitwarden / 1Password シークレット統合** —  /  プレフィクスで実行時解決
- **サブエージェントのライブ転写** —  実行中の中間出力をリアルタイム閲覧
- **配信台帳** — ゲートウェイ配信の成功/失敗/再試行を SQLite で履歴管理
- **プロファイル別ゲートウェイ ルーティング** — 同一ボットトークンで複数プロファイルを運用
- **新プロバイダ/モデル** — OpenRouter MoA、Kimi K2、GLM-4.5、Nemotron 3 Ultra、MiMo、Doubao 等
- **推論労力コントロール** — 会話単位で  切替
- **サブスクリプション管理** — Nous Portal + ツールゲートウェイ請求の統合ダッシュボード
- **セッション エクスポート（秘密情報スクラブ付き）** — Obsidian/Git 連携用
- **新プラットフォーム** — LINE（個人/公式）と SimpleX（メタデータなし E2EE）

### Files

-  — Japanese tweet draft with hashtags and emoji