### PR TITLE
chore: add media files and render outputs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -239,3 +239,34 @@ scripts/windows/watchdog-go/dist/
 # Go build artifacts
 *.exe
 nul
+
+# Media files - large render outputs, never commit
+*.mp4
+*.mp3
+*.wav
+*.ogg
+*.mov
+*.avi
+*.mkv
+*.webm
+*.flac
+*.m4a
+*.aac
+*.blend
+*.blend1
+*.blend2
+render_frames/
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.webp
+*.tiff
+*.tif
+*.bmp
+*.exr
+*.hdr
+concat_list.txt
+city_destruction_sim.py
+city_destruction_scene.py
+fix_lighting.py


### PR DESCRIPTION
## Summary
Add media files (MP4, audio formats) and render outputs (PNG sequences, Blender files, render scripts) to `.gitignore` to prevent committing large binary artifacts.

## Changes
- Added common video formats: .mp4, .mov, .avi, .mkv, .webm
- Added common audio formats: .mp3, .wav, .ogg, .flac, .m4a, .aac
- Added Blender project files: .blend, .blend1, .blend2
- Added render output directories: render_frames/
- Added image formats: .png, .jpg, .jpeg, .gif, .webp, .tiff, .tif, .bmp, .exr, .hdr
- Added project-specific render scripts and concat list: city_destruction_sim.py, city_destruction_scene.py, fix_lighting.py, concat_list.txt

## Rationale
These are large binary artifacts generated during local rendering/video production that should never be committed to the repository. They bloat the repo size and are regenerated locally.