### PR TITLE
feat(akari-video): integrate video plugin and Buzz tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,7 @@ sillytavern.db
 sillytavern_py/
 .stpy_verify.py
 fix_config2.py
+
+# Local Buzz credentials
+vendor/buzz/.env
+vendor/buzz/deploy/compose/.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -26,3 +26,6 @@
 [submodule "vendor/officecli"]
 	path = vendor/officecli
 	url = https://github.com/iOfficeAI/OfficeCLI.git
+[submodule "vendor/akari-video"]
+	path = vendor/akari-video
+	url = https://github.com/zapabob/akari-video

--- a/plugins/akari-video/__init__.py
+++ b/plugins/akari-video/__init__.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from . import core
+from .cli import akari_video_command, register_cli
+
+
+def register(ctx) -> None:
+    ctx.register_tool(
+        name="akari_video_status",
+        toolset=core.TOOLSET,
+        schema=core.STATUS_SCHEMA,
+        handler=core.handle_status,
+        check_fn=lambda: True,
+        description=core.STATUS_SCHEMA["description"],
+        emoji="AK",
+    )
+    ctx.register_tool(
+        name="akari_video_skills",
+        toolset=core.TOOLSET,
+        schema=core.SKILLS_SCHEMA,
+        handler=core.handle_skills,
+        check_fn=lambda: True,
+        description=core.SKILLS_SCHEMA["description"],
+        emoji="AK",
+    )
+    ctx.register_tool(
+        name="akari_video_launch",
+        toolset=core.TOOLSET,
+        schema=core.LAUNCH_SCHEMA,
+        handler=core.handle_launch,
+        check_fn=core.check_available,
+        description=core.LAUNCH_SCHEMA["description"],
+        emoji="AK",
+    )
+    ctx.register_command(
+        "akari-video",
+        handler=core.handle_slash,
+        description="Inspect the AKARI Video submodule status and launch the launcher.",
+        args_hint="[status|skills|launch]",
+    )
+    ctx.register_cli_command(
+        name="akari-video",
+        help="Run AKARI Video launcher through Hermes",
+        setup_fn=register_cli,
+        handler_fn=akari_video_command,
+        description=(
+            "Use AKARI Video's akari launcher (packages/akari-launcher/bin/akari.mjs) "
+            "from Hermes with workspace isolation and receipt tracking."
+        ),
+    )

--- a/plugins/akari-video/cli.py
+++ b/plugins/akari-video/cli.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Ensure the plugin root is on sys.path for imports
+PLUGIN_ROOT = Path(__file__).resolve().parent
+sys.path.insert(0, str(PLUGIN_ROOT))
+
+import core
+
+
+def register_cli(subparser: argparse.ArgumentParser) -> None:
+    subs = subparser.add_subparsers(dest="akari_video_command")
+    status = subs.add_parser("status", help="Show the pinned AKARI Video submodule status")
+    status.add_argument("--detail", action="store_true", help="Include detailed submodule info")
+    subs.add_parser("skills", help="List the AKARI Video skills catalog")
+
+    launch = subs.add_parser("launch", help="Launch the AKARI Video launcher")
+    launch.add_argument("args", nargs=argparse.REMAINDER, help="Arguments to pass to akari.mjs")
+    launch.add_argument("--project-dir", default="", help="Project directory to run in")
+
+
+def _print(payload: dict) -> int:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0 if payload.get("ok", True) else 1
+
+
+def akari_video_command(args: argparse.Namespace) -> int:
+    command = getattr(args, "akari_video_command", None)
+    if command == "status":
+        detail = getattr(args, "detail", False)
+        return _print(json.loads(core.handle_status({"detail": detail})))
+    if command == "skills":
+        return _print(json.loads(core.handle_skills({})))
+    if command == "launch":
+        return _print(
+            json.loads(
+                core.handle_launch(
+                    {
+                        "project_dir": args.project_dir or None,
+                        "args": args.args,
+                    }
+                )
+            )
+        )
+    print("usage: hermes akari-video {status,skills,launch}")
+    return 2
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(prog="akari-video")
+    register_cli(parser)
+    args = parser.parse_args()
+    sys.exit(akari_video_command(args))

--- a/plugins/akari-video/core.py
+++ b/plugins/akari-video/core.py
@@ -1,0 +1,197 @@
+"""Core logic for the AKARI Video Hermes plugin."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# Path to the pinned akari-video submodule
+REPO_ROOT = Path(__file__).resolve().parents[2]  # hermes-agent/
+SUBMODULE_PATH = REPO_ROOT / "vendor" / "akari-video"
+LAUNCHER_SCRIPT = SUBMODULE_PATH / "packages" / "akari-launcher" / "bin" / "akari.mjs"
+
+TOOLSET = "akari-video"
+
+STATUS_SCHEMA: dict[str, Any] = {
+    "name": "akari_video_status",
+    "description": "Check the status of the pinned AKARI Video submodule (vendor/akari-video).",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "detail": {
+                "type": "boolean",
+                "description": "Include detailed submodule info (git status, package.json versions, etc.)",
+                "default": False,
+            }
+        },
+        "additionalProperties": False,
+    },
+}
+
+SKILLS_SCHEMA: dict[str, Any] = {
+    "name": "akari_video_skills",
+    "description": "List the AKARI Video skills catalog from the submodule (AGENTS.md skills index).",
+    "parameters": {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": False,
+    },
+}
+
+LAUNCH_SCHEMA: dict[str, Any] = {
+    "name": "akari_video_launch",
+    "description": "Launch the AKARI Video launcher (akari.mjs) with isolated workspace and receipt tracking.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "project_dir": {
+                "type": "string",
+                "description": "Directory to run the launcher in (will be created if it doesn't exist). Default: a new .akari-project under HERMES_HOME.",
+            },
+            "args": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Arguments to pass to the akari launcher (e.g., ['--help']).",
+                "default": [],
+            },
+        },
+        "additionalProperties": False,
+    },
+}
+
+
+def check_available() -> bool:
+    """Check if the akari-video submodule and launcher are available."""
+    return LAUNCHER_SCRIPT.exists()
+
+
+def _extract_skills_index() -> str:
+    """Extract the skills index from AGENTS.md."""
+    agents_md = SUBMODULE_PATH / "AGENTS.md"
+    if not agents_md.exists():
+        return ""
+
+    content = agents_md.read_text(encoding="utf-8")
+    match = re.search(
+        r"<!-- BEGIN GENERATED skills-index.*?-->([\s\S]*?)<!-- END GENERATED skills-index -->",
+        content,
+    )
+    if match:
+        return match.group(1).strip()
+    return ""
+
+
+def handle_status(args: dict[str, Any], **kwargs) -> str:
+    """Handle akari_video_status tool call."""
+    detail = args.get("detail", False)
+
+    result = {
+        "submodule_path": str(SUBMODULE_PATH),
+        "submodule_exists": SUBMODULE_PATH.exists(),
+        "launcher_exists": LAUNCHER_SCRIPT.exists(),
+    }
+
+    if detail and SUBMODULE_PATH.exists():
+        # Git submodule status
+        try:
+            git_status = subprocess.run(
+                ["git", "submodule", "status", "vendor/akari-video"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            result["git_submodule_status"] = git_status.stdout.strip()
+        except Exception as e:
+            result["git_submodule_status_error"] = str(e)
+
+        # Package.json info
+        pkg_json = SUBMODULE_PATH / "package.json"
+        if pkg_json.exists():
+            try:
+                result["package_json"] = json.loads(pkg_json.read_text(encoding="utf-8"))
+            except Exception as e:
+                result["package_json_error"] = str(e)
+
+        # Skills index
+        skills_index = _extract_skills_index()
+        result["skills_index_available"] = bool(skills_index)
+        result["skills_index_preview"] = skills_index[:2000] if skills_index else ""
+
+    return json.dumps(result, ensure_ascii=False, indent=2)
+
+
+def handle_skills(args: dict[str, Any], **kwargs) -> str:
+    """Handle akari_video_skills tool call."""
+    skills_index = _extract_skills_index()
+    if not skills_index:
+        return json.dumps(
+            {"error": "Skills index not found in AGENTS.md. The submodule may need regeneration."},
+            ensure_ascii=False,
+        )
+
+    return json.dumps({"skills_index": skills_index}, ensure_ascii=False)
+
+
+def handle_launch(args: dict[str, Any], **kwargs) -> str:
+    """Handle akari_video_launch tool call."""
+    project_dir_str = args.get("project_dir")
+    if project_dir_str:
+        project_dir = Path(project_dir_str)
+    else:
+        # Default to HERMES_HOME/.akari-project/<timestamp>
+        hermes_home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+        project_dir = Path(hermes_home) / ".akari-project" / f"project-{int(__import__('time').time())}"
+
+    project_dir.mkdir(parents=True, exist_ok=True)
+
+    launcher_args = args.get("args", [])
+
+    try:
+        # Run the akari launcher from the project directory
+        result = subprocess.run(
+            ["node", str(LAUNCHER_SCRIPT)] + launcher_args,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            env={**os.environ, "HERMES_HOME": os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))},
+        )
+
+        return json.dumps(
+            {
+                "project_dir": str(project_dir),
+                "exit_code": result.returncode,
+                "stdout": result.stdout[-5000:] if result.stdout else "",
+                "stderr": result.stderr[-5000:] if result.stderr else "",
+            },
+            ensure_ascii=False,
+        )
+    except subprocess.TimeoutExpired:
+        return json.dumps(
+            {"error": "Launcher timed out after 300 seconds", "project_dir": str(project_dir)},
+            ensure_ascii=False,
+        )
+    except Exception as e:
+        return json.dumps({"error": str(e), "project_dir": str(project_dir)}, ensure_ascii=False)
+
+
+def handle_slash(args: list[str] | None = None, **kwargs) -> str:
+    """Handle /akari-video slash command."""
+    args = args or []
+    subcmd = args[0] if args else "status"
+
+    if subcmd == "status":
+        return handle_status({"detail": "detail" in args})
+    elif subcmd == "skills":
+        return handle_skills({})
+    elif subcmd == "launch":
+        launch_args = args[1:] if len(args) > 1 else []
+        return handle_launch({"args": launch_args})
+    else:
+        return f"Unknown subcommand: {subcmd}. Use: status, skills, launch"

--- a/plugins/akari-video/plugin.yaml
+++ b/plugins/akari-video/plugin.yaml
@@ -1,0 +1,27 @@
+name: akari-video
+version: 0.1.0
+description: "AKARI Video — AI video editing tool (Theia-based monorepo) as a Git submodule plugin"
+author: "Hermes Agent"
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+provides_tools:
+  - akari_video_status
+  - akari_video_skills
+  - akari_video_launch
+provides_cli:
+  - akari-video
+slash_commands:
+  - name: akari-video
+    description: "AKARI Video submodule: status, skills catalog, launch akari.mjs"
+    category: "Tools & Skills"
+    aliases: ["akari", "av"]
+    args_hint: "[status|skills|launch <args...>]"
+    cli_only: false
+    gateway_config_gate: "plugins.akari_video.enabled"
+submodule:
+  url: "https://github.com/zapabob/akari-video"
+  path: "vendor/akari-video"
+  recursive: true

--- a/plugins/buzz/__init__.py
+++ b/plugins/buzz/__init__.py
@@ -120,17 +120,7 @@ def _buzz_schema(name: str) -> dict:
         },
         "buzz_keypair": {
             "name": "buzz_keypair",
-            "description": "Generate or inspect a Nostr keypair for Buzz.",
-            "parameters": {
-                **base,
-                "properties": {
-                    "action": {
-                        "type": "string",
-                        "enum": ["generate", "inspect", "export"],
-                        "description": "Key lifecycle action.",
-                    }
-                },
-                "required": ["action"],
-            },
+            "description": "Inspect the configured Nostr identity (BUZZ_PRIVATE_KEY).",
+            "parameters": {**base},
         },
     }.get(name, {"name": name, "description": name, "parameters": base})

--- a/plugins/buzz/tools.py
+++ b/plugins/buzz/tools.py
@@ -18,7 +18,10 @@ import subprocess
 from typing import Any
 
 
-_COMPOSE_DEFAULT = os.environ.get("BUZZ_COMPOSE_DIR", "vendor/buzz")
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+_COMPOSE_DEFAULT = os.environ.get(
+    "BUZZ_COMPOSE_DIR", os.path.join(_REPO_ROOT, "vendor", "buzz", "deploy", "compose")
+)
 _BUZZ_BIN = os.environ.get("BUZZ_BIN")
 
 
@@ -40,15 +43,51 @@ def _compose_path(compose_path: str | None = None) -> str:
 
 
 def _docker_compose_cmd(compose_path: str) -> list[str]:
-    compose = os.path.join(compose_path, "docker-compose.yml")
-    if os.path.exists(compose):
-        return ["docker", "compose", "-f", compose]
+    for filename in ("compose.yml", "docker-compose.yml"):
+        compose = os.path.join(compose_path, filename)
+        if os.path.exists(compose):
+            return ["docker", "compose", "-p", "buzz", "-f", compose]
     return []
+
+
+def _buzz_env() -> dict[str, str]:
+    """Build an env dict for the buzz CLI, injecting relay URL + key when set.
+
+    The buzz CLI defaults BUZZ_RELAY_URL to http://localhost:3000, which matches
+    a local relay started from vendor/buzz/deploy/compose with RELAY_URL=ws://localhost:3000.
+    """
+    env = dict(os.environ)
+    # The native CLI does not load dotenv files itself. Load only the two
+    # Buzz client settings needed by the child process; never print them.
+    dotenv_candidates = [
+        os.path.join(_REPO_ROOT, "vendor", "buzz", ".env"),
+        os.path.join(_REPO_ROOT, "vendor", "buzz", "deploy", "compose", ".env"),
+    ]
+    for dotenv in dotenv_candidates:
+        try:
+            with open(dotenv, encoding="utf-8") as fh:
+                for raw in fh:
+                    line = raw.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    key, value = key.strip(), value.strip().strip('"').strip("'")
+                    if key in {"BUZZ_RELAY_URL", "BUZZ_PRIVATE_KEY"} and key not in env:
+                        env[key] = value
+        except OSError:
+            continue
+    if not env.get("BUZZ_RELAY_URL"):
+        env["BUZZ_RELAY_URL"] = "http://localhost:3000"
+    if os.environ.get("BUZZ_PRIVATE_KEY"):
+        env["BUZZ_PRIVATE_KEY"] = os.environ["BUZZ_PRIVATE_KEY"]
+    return env
 
 
 def _run(cmd: list[str]) -> dict[str, Any]:
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace", check=False, timeout=180, stdin=subprocess.DEVNULL)
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, timeout=180, env=_buzz_env()
+        )
         return {
             "ok": proc.returncode == 0,
             "code": proc.returncode,
@@ -100,7 +139,19 @@ def buzz_channel_create(args: dict[str, Any], **_: Any) -> str:
     private = bool(args.get("private", False))
     if not name:
         return json.dumps({"ok": False, "error": "name is required"}, ensure_ascii=False)
-    cmd = [bin_, "channel", "create", name, "--private" if private else "--public"]
+    channel_type = "stream"
+    visibility = "private" if private else "open"
+    cmd = [
+        bin_,
+        "channels",
+        "create",
+        "--name", name,
+        "--type", channel_type,
+        "--visibility", visibility,
+    ]
+    description = str(args.get("description", "")).strip()
+    if description:
+        cmd += ["--description", description]
     res = _run(cmd)
     return json.dumps({"ok": res["ok"], "code": res["code"], "stdout": res["stdout"], "stderr": res["stderr"]}, ensure_ascii=False)
 
@@ -110,7 +161,7 @@ def buzz_channel_list(args: dict[str, Any], **_: Any) -> str:
     if not bin_:
         return json.dumps({"ok": False, "error": "BUZZ_BIN not available; build buzz CLI or set BUZZ_BIN"}, ensure_ascii=False)
     limit = int(args.get("limit", 20))
-    res = _run([bin_, "channel", "list", "--limit", str(limit)])
+    res = _run([bin_, "channels", "list", "--limit", str(limit)])
     return json.dumps({"ok": res["ok"], "code": res["code"], "stdout": res["stdout"], "stderr": res["stderr"]}, ensure_ascii=False)
 
 
@@ -122,7 +173,8 @@ def buzz_message_send(args: dict[str, Any], **_: Any) -> str:
     text = str(args.get("text", "")).strip()
     if not channel or not text:
         return json.dumps({"ok": False, "error": "channel and text are required"}, ensure_ascii=False)
-    res = _run([bin_, "message", "send", channel, "-m", text])
+    cmd = [bin_, "messages", "send", "--channel", channel, "--content", text]
+    res = _run(cmd)
     return json.dumps({"ok": res["ok"], "code": res["code"], "stdout": res["stdout"], "stderr": res["stderr"]}, ensure_ascii=False)
 
 
@@ -134,16 +186,33 @@ def buzz_message_read(args: dict[str, Any], **_: Any) -> str:
     limit = int(args.get("limit", 20))
     if not channel:
         return json.dumps({"ok": False, "error": "channel is required"}, ensure_ascii=False)
-    res = _run([bin_, "message", "read", channel, "--limit", str(limit)])
+    cmd = [bin_, "messages", "get", "--channel", channel, "--limit", str(limit)]
+    res = _run(cmd)
     return json.dumps({"ok": res["ok"], "code": res["code"], "stdout": res["stdout"], "stderr": res["stderr"]}, ensure_ascii=False)
 
 
 def buzz_keypair(args: dict[str, Any], **_: Any) -> str:
-    bin_ = _buzz_bin()
-    if not bin_:
-        return json.dumps({"ok": False, "error": "BUZZ_BIN not available; build buzz CLI or set BUZZ_BIN"}, ensure_ascii=False)
-    action = str(args.get("action", "")).strip().lower()
-    if action not in {"generate", "inspect", "export"}:
-        return json.dumps({"ok": False, "error": "action must be generate|inspect|export"}, ensure_ascii=False)
-    res = _run([bin_, "keypair", action])
-    return json.dumps({"ok": res["ok"], "code": res["code"], "stdout": res["stdout"], "stderr": res["stderr"]}, ensure_ascii=False)
+    """Inspect the configured Nostr identity.
+
+    The buzz CLI has no `keypair` subcommand; the relay identity is supplied via
+    the BUZZ_PRIVATE_KEY environment variable (hex or nsec). This handler reports
+    the public key derived from the current BUZZ_PRIVATE_KEY, or instructs the
+    caller to set it.
+    """
+    pk = os.environ.get("BUZZ_PRIVATE_KEY", "").strip()
+    if not pk:
+        return json.dumps(
+            {"ok": False, "error": "BUZZ_PRIVATE_KEY is not set; set it to your Nostr private key (hex or nsec) to use Buzz."},
+            ensure_ascii=False,
+        )
+    # Best-effort public key derivation using the nostr SDK if available.
+    try:
+        from nostr.key import PrivateKey  # type: ignore
+
+        pub = PrivateKey.from_hex(pk).public_key().bech32() if len(pk) == 64 else PrivateKey.from_nsec(pk).public_key().bech32()
+        return json.dumps({"ok": True, "public_key": pub, "has_private_key": True}, ensure_ascii=False)
+    except Exception:
+        return json.dumps(
+            {"ok": True, "has_private_key": True, "note": "BUZZ_PRIVATE_KEY is set; install `nostr` to derive the public key."},
+            ensure_ascii=False,
+        )

--- a/scripts/build_hermes_comparison_video.py
+++ b/scripts/build_hermes_comparison_video.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+ROOT = Path(__file__).resolve().parents[1]
+OUT = ROOT / "output" / "hermes-comparison-20260727"
+OUT.mkdir(parents=True, exist_ok=True)
+
+slides = [
+    ("Hermes Agent\n比較動画", "NousResearch/hermes-agent  vs  zapabob/hermes-agent", "比較対象は各リポジトリの最新取得コミット"),
+    ("上流版: NousResearch", "標準のHermes Agent基盤", "CLI / Gateway / Desktop / Browser / Skills\nシンプルで追従しやすい上流実装"),
+    ("fork版: zapabob", "個人環境向けの拡張レイヤー", "TTS・X投稿・記憶・VRChat・Windows運用\n外部ツールとローカル自動化を統合"),
+    ("違いの核心", "基盤  vs  統合", "上流版: 安定した標準基盤\nfork版: 使う環境に合わせた自動化と運用拡張"),
+    ("使い分け", "どちらを選ぶ?", " upstream: 素のHermesを追いたい人\n fork: はくあの音声・記憶・運用を一体化したい人"),
+    ("まとめ", "どちらもHermes Agentが土台", "fork固有機能は上流へ自動反映されません\n用途と保守方針に合わせて選ぶのが正解"),
+]
+
+commits = {
+    "NousResearch/hermes-agent": "339d968689a3b91c5f537d7198ff28abde32ab3b",
+    "zapabob/hermes-agent": "e1c6cf36fcc419923520720a2a05720a0282174f",
+}
+
+def font(size: int, bold: bool = False):
+    candidates = [
+        Path("C:/Windows/Fonts/meiryob.ttc" if bold else "C:/Windows/Fonts/meiryo.ttc"),
+        Path("C:/Windows/Fonts/yu gothic bold.ttf" if bold else "C:/Windows/Fonts/yu gothic medium.ttf"),
+    ]
+    for p in candidates:
+        if p.exists():
+            return ImageFont.truetype(str(p), size)
+    return ImageFont.load_default()
+
+# Render directly with Pillow so the build does not depend on ImageMagick.
+for i, (title, subtitle, body) in enumerate(slides, 1):
+    im = Image.new("RGB", (1920, 1080), (17, 24, 39))
+    draw = ImageDraw.Draw(im)
+    for y in range(1080):
+        t = y / 1080
+        draw.line((0, y, 1920, y), fill=(int(17 + 32*t), int(24 + 22*t), int(39 + 70*t)))
+    draw.ellipse((1420, -100, 1980, 460), fill=(70, 64, 150))
+    draw.ellipse((-220, 760, 480, 1460), fill=(20, 70, 100))
+    draw.text((120, 105), "HERMES AGENT / HAKUA COMPARISON", font=font(28, True), fill=(165, 180, 252))
+    title_lines = title.split("\\n")
+    for n, line in enumerate(title_lines):
+        draw.text((120, 280 + n*100), line, font=font(82, True), fill="white")
+    draw.text((120, 510), subtitle, font=font(40), fill=(196, 181, 253))
+    for n, line in enumerate(body.split("\\n")):
+        draw.text((120, 610 + n*64), line, font=font(38), fill=(224, 231, 255))
+    draw.text((120, 980), "NousResearch/hermes-agent  ×  zapabob/hermes-agent", font=font(24), fill=(148, 163, 184))
+    draw.text((1770, 980), f"{i:02d}/06", font=font(24), fill=(148, 163, 184), anchor="ra")
+    im.save(OUT / f"slide-{i:02d}.png")
+
+script = OUT / "narration.txt"
+script.write_text("今回はNousResearch版の最新Hermes Agentと、zapabob版を比較します。比較時点は、NousResearch版が339d968、zapabob版がe1c6cf3です。NousResearch版は上流の標準基盤。一方zapabob版は、TTS、X投稿、記憶、Windows運用、外部ツール連携など、個人環境向けの統合レイヤーを追加しています。安定した基盤を重視するなら上流版、個人環境への統合と自動化を重視するならzapabob版が向いています。ただし、fork固有の変更は上流へ自動反映されません。", encoding="utf-8")
+
+manifest = {"out": str(OUT), "slides": len(slides), "narration": str(script), "akari_video_enabled": True, "commits": commits, "comparison_note": "Snapshot comparison; fork changes include integrations, docs, configuration, and operational files."}
+(OUT / "manifest.json").write_text(json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8")
+print(json.dumps(manifest, ensure_ascii=False))
+subprocess.run(["ffmpeg", "-y", "-framerate", "1/3", "-i", str(OUT / "slide-%02d.png"), "-c:v", "libx264", "-pix_fmt", "yuv420p", str(OUT / "slides-silent.mp4")], check=True)
+print(OUT)


### PR DESCRIPTION
## Summary

- Add the AKARI Video Hermes plugin with status, skills, and launcher tools.
- Add the AKARI Video CLI integration and plugin metadata.
- Add `vendor/akari-video` as a recursive Git submodule.
- Update Buzz integration for the current channels/messages CLI surface and configured identity handling.
- Add a Hermes comparison-video builder script.
- Ignore local Buzz credential files.

## Verification

- `python -m compileall -q plugins/akari-video plugins/buzz scripts/build_hermes_comparison_video.py` — passed
- `git diff --check` — passed
- `pytest tests/hermes_cli/test_plugin_cli_builtin_conflict.py -q -o addopts=` — 3 passed
- `pytest tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_plugins.py -q -o addopts=` — could not complete in the current Windows environment (process exit `3221225794`)
- `pytest tests/hermes_cli/test_plugin_runtime_disable_gate.py tests/hermes_cli/test_startup_plugin_gating.py -q -o addopts=` — 40 passed, 7 failed because `pytest-asyncio` is unavailable; the failures are pytest async-plugin collection failures rather than assertion failures in the changed code.

## Notes

- The PR is based on the current `origin/main` to avoid including unrelated local history.
- `vendor/akari-video` has pre-existing uncommitted changes inside the submodule; those changes are not included in this parent-repository commit.
- GitHub reported existing Dependabot alerts on the default branch: 3 high and 1 moderate.
