### PR TITLE
docs(readme): sync git submodule list with .gitmodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,16 +289,18 @@ separately maintainable.
 
 | Path | Repository | What it is |
 | --- | --- | --- |
-| `vendor/openclaw-mirror/AI-Scientist` | `https://github.com/SakanaAI/AI-Scientist.git` | AI research automation framework for experiment-generation/evaluation loops. |
+| `vendor/openclaw-mirror/AI-Scientist` | `https://github.com/zapabob/AI-Scientist.git` | AI research automation framework for experiment-generation/evaluation loops. |
 | `vendor/openclaw-mirror/ATLAS` | `https://github.com/zapabob/ATLAS.git` | Fork-maintained ATLAS integration used by OpenClaw mirror workflows. |
-| `vendor/openclaw-mirror/ShinkaEvolve` | `https://github.com/SakanaAI/ShinkaEvolve.git` | Evolutionary optimization framework used for self-improving workflow experiments. |
-| `vendor/neuro-sdk` | `https://github.com/VedalAI/neuro-sdk.git` | VedalAI Neuro SDK integration surface for agent extensions. |
-| `vendor/openmanus` | `https://github.com/FoundationAgents/OpenManus.git` | OpenManus upstream code used via Hermes adapter/plugin boundaries. |
-| `vendor/SillyTavern` | `https://github.com/SillyTavern/SillyTavern.git` | SillyTavern upstream UI/runtime dependency for related integration workflows. |
+| `vendor/openclaw-mirror/ShinkaEvolve` | `https://github.com/zapabob/ShinkaEvolve.git` | Evolutionary optimization framework used for self-improving workflow experiments. |
+| `vendor/neuro-sdk` | `https://github.com/zapabob/neuro-sdk.git` | VedalAI Neuro SDK integration surface for agent extensions. |
+| `vendor/openmanus` | `https://github.com/zapabob/OpenManus.git` | OpenManus upstream code used via Hermes adapter/plugin boundaries. |
+| `vendor/SillyTavern` | `https://github.com/zapabob/SillyTavern.git` | SillyTavern upstream UI/runtime dependency for related integration workflows. |
 | `vendor/shinka-osint` | `https://github.com/zapabob/ShinkaEvolve-OSINT.git` | Fork OSINT + MILSPEC workflow stack (ShinkaEvolve-OSINT). |
-| `vendor/buzz` | `https://github.com/block/buzz.git` | Block Buzz relay/clients codebase vendored for interoperability and reference. |
-| `vendor/officecli` | `https://github.com/iOfficeAI/OfficeCLI.git` | OfficeCLI integration for productivity and office-task automation tooling. |
-| `vendor/akari-video` | `https://github.com/zapabob/akari-video` | AKARI Video monorepo used for video-workflow integrations. |
+| `vendor/buzz` | `https://github.com/zapabob/buzz.git` | Block Buzz relay/clients codebase vendored for interoperability and reference. |
+| `vendor/officecli` | `https://github.com/zapabob/OfficeCLI.git` | OfficeCLI integration for productivity and office-task automation tooling. |
+| `vendor/akari-video` | `https://github.com/zapabob/akari-video.git` | AKARI Video monorepo used for video-workflow integrations. |
+| `vendor/cloakbrowser` | `https://github.com/zapabob/cloakbrowser.git` | CloakBrowser local browser fallback for web research (anti-detect browsing). |
+| `vendor/airi` | `https://github.com/zapabob/airi.git` | Project AIRI companion shell (VRM/TTS) as a Hermes-managed Electron worker. |
 
 Current local initialization state (`git submodule status`) may differ by
 checkout. Entries prefixed with `-` are present in `.gitmodules` but not


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Update the fork `README.md` Git Submodules table to match `.gitmodules`.

- Point every `vendor/` entry at the zapabob fork URL recorded in `.gitmodules`
- Add missing `vendor/cloakbrowser` and `vendor/airi`
- Normalize `akari-video` URL to include `.git`

## Why

The README table still listed several upstream remotes and omitted two submodules that are already registered in `.gitmodules`, which misleads contributors about what this fork vendors.

## Test plan

- [x] Diff table paths/URLs against `.gitmodules`
- [ ] Confirm Markdown table renders on GitHub

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

