### PR TITLE
fix(fallback): harden resolve_fallback_chain imports for mixed checkouts

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -50,7 +50,15 @@ logger = logging.getLogger(__name__)
 # Suppress startup messages for clean CLI experience
 os.environ["HERMES_QUIET"] = "1"  # Our own modules
 
-from hermes_cli.fallback_config import get_fallback_chain, resolve_fallback_chain
+from hermes_cli.fallback_config import get_fallback_chain
+
+try:
+    from hermes_cli.fallback_config import resolve_fallback_chain
+except ImportError:  # pragma: no cover - mixed/partial checkout shim
+    # Older trees only exported get_fallback_chain; Desktop/gateway callers that
+    # expect resolve_fallback_chain would otherwise crash at import time.
+    resolve_fallback_chain = get_fallback_chain
+
 from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
 from hermes_cli.cli_commands_mixin import CLICommandsMixin
 from hermes_cli.cli_billing_mixin import CLIBillingMixin

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -60,7 +60,12 @@ from agent.conversation_compression import (
 from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 from agent.i18n import t
 from hermes_cli.config import cfg_get
-from hermes_cli.fallback_config import get_fallback_chain, resolve_fallback_chain
+from hermes_cli.fallback_config import get_fallback_chain
+
+try:
+    from hermes_cli.fallback_config import resolve_fallback_chain
+except ImportError:  # pragma: no cover - mixed/partial checkout shim
+    resolve_fallback_chain = get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
 # Bounds the per-session AIAgent cache to prevent unbounded growth in

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -934,6 +934,39 @@ def run_doctor(args):
             check_ok(name, "(optional)")
         except ImportError:
             check_warn(name, "(optional, not installed)")
+
+    # Mixed/partial checkouts (Desktop pointing at an older hermes root while
+    # newer gateway/TUI code is loaded) previously crashed prompts with:
+    #   ImportError: cannot import name 'resolve_fallback_chain'
+    # Surface that API gap here so `hermes doctor` points at git pull / root pin.
+    try:
+        from hermes_cli import fallback_config as _fb_cfg
+
+        if not hasattr(_fb_cfg, "resolve_fallback_chain"):
+            _fail_and_issue(
+                "fallback_config.resolve_fallback_chain",
+                "(missing — LLM provider fallback will fail)",
+                "Update this hermes-agent checkout to current main "
+                "(git pull) or point Desktop at HERMES_DESKTOP_HERMES_ROOT "
+                "that includes resolve_fallback_chain.",
+                issues,
+            )
+        elif not hasattr(_fb_cfg, "get_fallback_chain"):
+            _fail_and_issue(
+                "fallback_config.get_fallback_chain",
+                "(missing)",
+                "fallback_config.py is incomplete — reinstall or git checkout hermes_cli/fallback_config.py",
+                issues,
+            )
+        else:
+            check_ok("fallback_config API", "(get + resolve)")
+    except ImportError as exc:
+        _fail_and_issue(
+            "fallback_config",
+            f"(import failed: {exc})",
+            "hermes_cli.fallback_config could not be imported",
+            issues,
+        )
     
     _section("Configuration Files")
     # Managed scope (administrator-pinned config/env), when present.

--- a/tests/hermes_cli/test_fallback_resolve_import_shim.py
+++ b/tests/hermes_cli/test_fallback_resolve_import_shim.py
@@ -1,0 +1,23 @@
+"""Guard against mixed-checkout ImportError for resolve_fallback_chain."""
+
+from __future__ import annotations
+
+import hermes_cli.fallback_config as fb
+
+
+def test_fallback_config_exports_resolve_and_get():
+    """Desktop/gateway crash when resolve_fallback_chain is missing from the tree."""
+    assert callable(getattr(fb, "get_fallback_chain", None))
+    assert callable(getattr(fb, "resolve_fallback_chain", None))
+
+
+def test_resolve_fallback_chain_import_shim_survives_missing_symbol(monkeypatch):
+    """Callers must degrade to get_fallback_chain instead of crashing at import."""
+    monkeypatch.delattr(fb, "resolve_fallback_chain", raising=False)
+
+    try:
+        from hermes_cli.fallback_config import resolve_fallback_chain as resolved
+    except ImportError:
+        from hermes_cli.fallback_config import get_fallback_chain as resolved
+
+    assert resolved is fb.get_fallback_chain

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5841,7 +5841,10 @@ def _load_fallback_model():
     (deduped on provider/model/base_url), then NVIDIA/Nous dynamic entries
     expanded for runtime failover.
     """
-    from hermes_cli.fallback_config import resolve_fallback_chain
+    try:
+        from hermes_cli.fallback_config import resolve_fallback_chain
+    except ImportError:  # pragma: no cover - mixed/partial checkout shim
+        from hermes_cli.fallback_config import get_fallback_chain as resolve_fallback_chain
 
     return resolve_fallback_chain(_load_cfg())
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Desktop prompts were crashing with:

```text
ImportError: cannot import name 'resolve_fallback_chain' from 'hermes_cli.fallback_config'
```

when the running tree mixed newer CLI/gateway/TUI callers with an older `hermes_cli/fallback_config.py` (pre `98bf5f05e`, e.g. tip `94f8166`) that only exported `get_fallback_chain`.

## Changes

- Soft-import `resolve_fallback_chain` in `cli.py`, `gateway/run.py`, and `tui_gateway/server.py`, falling back to `get_fallback_chain` on `ImportError`
- `hermes doctor` reports a missing `resolve_fallback_chain` API with a clear `git pull` / `HERMES_DESKTOP_HERMES_ROOT` hint
- Regression test for the export + import shim

## Immediate user recovery (does not require this PR)

```powershell
cd "C:\Users\downl\Documents\New project\hermes-agent"
git fetch origin
git checkout main
git pull origin main
py -3 -c "from hermes_cli.fallback_config import resolve_fallback_chain; print('OK')"
```

Then restart Desktop / gateway.

## Test plan

- [x] `scripts/run_tests.sh tests/hermes_cli/test_fallback_chain.py tests/hermes_cli/test_fallback_config.py tests/hermes_cli/test_fallback_resolve_import_shim.py -q`
- [ ] Restart Desktop against an updated main checkout and confirm prompt no longer shows the ImportError

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

