### PR TITLE
fix(desktop): 「後で」で更新ダイアログの snooze を効かせる

### DIFF
--- a/apps/desktop/src/app/updates-overlay.tsx
+++ b/apps/desktop/src/app/updates-overlay.tsx
@@ -33,6 +33,7 @@ import {
   applyUpdates,
   checkBackendUpdates,
   checkUpdates,
+  dismissUpdateReminder,
   resetUpdateApplyState,
   setUpdateOverlayOpen,
   type UpdateApplyState
@@ -83,6 +84,12 @@ export function UpdatesOverlay() {
   const handleClose = (next: boolean) => {
     if (phase === 'applying') {
       return
+    }
+
+    // 「後で」/ dismiss while an update is still waiting must snooze the gift
+    // toast — otherwise checkUpdates on focus/poll re-opens the same nag.
+    if (!next && phase === 'idle' && updateAvailable) {
+      dismissUpdateReminder()
     }
 
     setUpdateOverlayOpen(next)

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -43,6 +43,7 @@ vi.mock('@/hermes', () => ({
 
 const {
   maybeNotifyUpdateAvailable,
+  dismissUpdateReminder,
   checkBackendUpdates,
   $backendUpdateStatus,
   applyBackendUpdate,
@@ -121,6 +122,19 @@ describe('maybeNotifyUpdateAvailable', () => {
 
   it('does nothing when already up to date', () => {
     maybeNotifyUpdateAvailable(status({ behind: 0 }))
+    expect(notifySpy).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet after dismissUpdateReminder (overlay「後で」)', () => {
+    maybeNotifyUpdateAvailable(status())
+    expect(notifySpy).toHaveBeenCalledTimes(1)
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+
+    dismissUpdateReminder()
+    expect(dismissSpy).toHaveBeenCalledWith('desktop-update-available')
+
+    maybeNotifyUpdateAvailable(status({ targetSha: 'sha-b', behind: 9 }))
     expect(notifySpy).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -87,6 +87,18 @@ function isUpdateToastSnoozed(): boolean {
   return Number.isFinite(until) && Date.now() < until
 }
 
+/**
+ * User said "maybe later" (or closed the updates overlay while an update is
+ * still available). Mirror toast-dismiss: start the cooldown and clear any
+ * lingering gift toast so focus/poll rechecks don't immediately re-nag.
+ * Closing without this left the overlay feeling "broken" — click Later, then
+ * the same prompt returns on the next checkUpdates().
+ */
+export function dismissUpdateReminder(): void {
+  snoozeUpdateToast()
+  dismissNotification(UPDATE_TOAST_ID)
+}
+
 // Must match tui_gateway's DESKTOP_BACKEND_CONTRACT that this build was written
 // against. The backend reports its own value in session runtime info; a lower
 // value (or none — a pre-GUI checkout) means GUI<->backend skew.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

ステータスバーに Client `v0.16.2 (c3862)` が出ている状態での「新しい更新が利用可能」は、backend の ImportError 修正とは別件（クライアントが数千 commit 遅れている正当な通知）。

一方で、オーバーレイの「後で」がトースト dismiss と同じ 24h snooze を開始していなかったため、フォーカス／ポーリングの `checkUpdates` ですぐ再出現していた。

## Changes

- `dismissUpdateReminder()` — snooze + gift toast dismiss
- Idle + update available でオーバーレイを閉じたら呼ぶ
- vitest: overlay「後で」相当の snooze をカバー

## Test plan

- [x] `npx vitest run src/store/updates.test.ts` (31 passed)
- [ ] Windows Desktop: 更新ダイアログで「後で」→ 再フォーカスしてもすぐ再表示されない
- [ ] 「今すぐ更新」で Client を追いつかせるとダイアログ自体が消える
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

