### PR TITLE
fix(windows): Desktop ショートカットを Documents ソース起動へ

### DIFF
--- a/scripts/create-hermes-desktop-shortcuts.ps1
+++ b/scripts/create-hermes-desktop-shortcuts.ps1
@@ -246,15 +246,52 @@ function New-HermesPowerShellScriptShortcut {
         -IconLocation "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe,0"
 }
 
+function Get-ManagedHermesAgentRoot {
+    if (-not $env:LOCALAPPDATA) {
+        return $null
+    }
+    return Join-Path $env:LOCALAPPDATA "hermes\hermes-agent"
+}
+
+function Test-IsManagedHermesAgentRoot {
+    param([string]$RepoRoot)
+
+    $managed = Get-ManagedHermesAgentRoot
+    if (-not $managed) {
+        return $false
+    }
+
+    try {
+        $a = [System.IO.Path]::GetFullPath($RepoRoot).TrimEnd('\')
+        $b = [System.IO.Path]::GetFullPath($managed).TrimEnd('\')
+        return ($a -ieq $b)
+    }
+    catch {
+        return $false
+    }
+}
+
 function Resolve-PackagedHermesDesktop {
     param([string]$RepoRoot)
 
-    $candidates = @(
-        (Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe"),
-        (Join-Path $RepoRoot "apps\desktop\release\win-unpacked\Hermes.exe")
-    )
+    # Dev checkouts (Documents, clones): prefer THAT tree's win-unpacked first so a
+    # stale %LOCALAPPDATA% Hermes.exe does not win and keep Client at cNNNN.
+    # Managed install root: keep LOCALAPPDATA packaged exe as primary.
+    $candidates = if (Test-IsManagedHermesAgentRoot -RepoRoot $RepoRoot) {
+        @(
+            (Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe"),
+            (Join-Path $RepoRoot "apps\desktop\release\win-unpacked\Hermes.exe")
+        )
+    }
+    else {
+        @(
+            (Join-Path $RepoRoot "apps\desktop\release\win-unpacked\Hermes.exe"),
+            (Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe")
+        )
+    }
+
     foreach ($exe in $candidates) {
-        if (Test-Path -LiteralPath $exe) {
+        if ($exe -and (Test-Path -LiteralPath $exe)) {
             return $exe
         }
     }
@@ -287,28 +324,39 @@ function New-HermesDesktopShortcut {
         [string]$LinkPath,
         [string]$RepoRoot,
         [string]$HermesHome,
-        [string]$StartScript
+        [string]$StartScript,
+        [switch]$PreferSource
     )
 
-    # Prefer packaged Hermes.exe (.lnk -> exe + Hermes icon), not a PowerShell/.ps1 wrapper.
-    $hermesExe = Resolve-PackagedHermesDesktop -RepoRoot $RepoRoot
-    if ($hermesExe) {
-        $workDir = Split-Path -Parent $hermesExe
-        $icon = Resolve-HermesDesktopIcon -RepoRoot $RepoRoot -HermesExe $hermesExe
-        return New-HermesShortcut `
-            -LinkPath $LinkPath `
-            -TargetPath $hermesExe `
-            -Arguments "" `
-            -WorkingDirectory $workDir `
-            -Description "Hermes Desktop (packaged Hermes.exe; HERMES_DESKTOP_* set by Electron/main)" `
-            -IconLocation $icon `
-            -WindowStyle 1
+    # Dev / Documents checkouts: always launch via start-hermes-desktop.ps1 so
+    # HERMES_DESKTOP_HERMES_ROOT pins the tree you just pulled. Packaged
+    # %LOCALAPPDATA%\...\Hermes.exe ignores Documents and keeps showing cNNNN.
+    # Managed install: keep .lnk → Hermes.exe when present.
+    $useSource = $PreferSource -or -not (Test-IsManagedHermesAgentRoot -RepoRoot $RepoRoot)
+
+    if (-not $useSource) {
+        $hermesExe = Resolve-PackagedHermesDesktop -RepoRoot $RepoRoot
+        if ($hermesExe) {
+            $workDir = Split-Path -Parent $hermesExe
+            $icon = Resolve-HermesDesktopIcon -RepoRoot $RepoRoot -HermesExe $hermesExe
+            return New-HermesShortcut `
+                -LinkPath $LinkPath `
+                -TargetPath $hermesExe `
+                -Arguments "" `
+                -WorkingDirectory $workDir `
+                -Description "Hermes Desktop (packaged Hermes.exe; HERMES_DESKTOP_* set by Electron/main)" `
+                -IconLocation $icon `
+                -WindowStyle 1
+        }
     }
 
-    # Fallback: source launch via start-hermes-desktop.ps1 when packaged exe is missing.
     $hermesIcon = Join-Path $RepoRoot ".venv\Scripts\hermes.exe"
+    $packagedForIcon = Resolve-PackagedHermesDesktop -RepoRoot $RepoRoot
     $icon = if (Test-Path -LiteralPath $hermesIcon) {
         "$hermesIcon,0"
+    }
+    elseif ($packagedForIcon) {
+        "$packagedForIcon,0"
     }
     else {
         "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe,0"
@@ -319,7 +367,7 @@ function New-HermesDesktopShortcut {
         -TargetPath "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe" `
         -Arguments "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$StartScript`" -HermesRoot `"$RepoRoot`" -Cwd `"$RepoRoot`" -HermesHome `"$HermesHome`"" `
         -WorkingDirectory $RepoRoot `
-        -Description "Hermes Desktop connected to the canonical source checkout" `
+        -Description "Hermes Desktop → source checkout ($RepoRoot)" `
         -IconLocation $icon `
         -WindowStyle 7
 }

--- a/scripts/windows/Retarget-HermesDesktopShortcut.ps1
+++ b/scripts/windows/Retarget-HermesDesktopShortcut.ps1
@@ -1,0 +1,72 @@
+# Retarget Desktop Hermes shortcuts to the Documents/source checkout.
+# Packaged %LOCALAPPDATA%\...\Hermes.exe ignores Documents pulls and keeps
+# Client at cNNNN — this .lnk launches start-hermes-desktop.ps1 instead.
+#
+# Usage:
+#   powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\Retarget-HermesDesktopShortcut.ps1
+#   powershell ... -File scripts\windows\Retarget-HermesDesktopShortcut.ps1 -RepoRoot "D:\src\hermes-agent"
+
+param(
+    [string]$RepoRoot = "C:\Users\downl\Documents\New project\hermes-agent",
+    [string]$HermesHome = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $RepoRoot)) {
+    throw "RepoRoot not found: $RepoRoot"
+}
+
+$RepoRoot = (Resolve-Path -LiteralPath $RepoRoot).Path
+$StartScript = Join-Path $RepoRoot "scripts\windows\start-hermes-desktop.ps1"
+if (-not (Test-Path -LiteralPath $StartScript)) {
+    throw "Missing start script: $StartScript"
+}
+
+. (Join-Path $RepoRoot "scripts\windows\Resolve-CanonicalHermesHome.ps1")
+$HermesHome = Resolve-CanonicalHermesHome -Preferred $HermesHome -RepoRoot $RepoRoot
+
+$psExe = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe"
+$args = "-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File `"$StartScript`" -HermesRoot `"$RepoRoot`" -Cwd `"$RepoRoot`" -HermesHome `"$HermesHome`""
+
+$icon = Join-Path $RepoRoot ".venv\Scripts\hermes.exe"
+if (-not (Test-Path -LiteralPath $icon)) {
+    $icon = Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe"
+}
+$iconLoc = if (Test-Path -LiteralPath $icon) { "$icon,0" } else { "$psExe,0" }
+
+$userDesktop = [Environment]::GetFolderPath("Desktop")
+$folder = Join-Path $userDesktop "Hermes Agent"
+New-Item -ItemType Directory -Path $folder -Force | Out-Null
+
+$targets = @(
+    (Join-Path $userDesktop "Hermes.lnk"),
+    (Join-Path $userDesktop "Hermes Desktop.lnk"),
+    (Join-Path $folder "Hermes Desktop.lnk"),
+    (Join-Path $folder "Hermes.lnk")
+)
+
+# Kill stale packaged Desktop so the next launch is the retargeted one.
+Get-Process Hermes, electron -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+
+$Wsh = New-Object -ComObject WScript.Shell
+$written = @()
+foreach ($lnk in $targets) {
+    $sc = $Wsh.CreateShortcut($lnk)
+    $sc.TargetPath = $psExe
+    $sc.Arguments = $args
+    $sc.WorkingDirectory = $RepoRoot
+    $sc.Description = "Hermes Desktop → source ($RepoRoot)"
+    $sc.WindowStyle = 7
+    $sc.IconLocation = $iconLoc
+    $sc.Save()
+    $written += $lnk
+    Write-Host "Wrote $lnk"
+    Write-Host "  -> $psExe"
+    Write-Host "  $args"
+}
+
+Write-Host ""
+Write-Host "Done. Double-click Desktop\Hermes.lnk (or Hermes Agent\Hermes Desktop.lnk)." -ForegroundColor Green
+Write-Host "Update root is now Documents; Client cNNNN should clear after restart." -ForegroundColor DarkGray
+$written

--- a/scripts/windows/Sync-HermesUpdateTrees.ps1
+++ b/scripts/windows/Sync-HermesUpdateTrees.ps1
@@ -1,0 +1,162 @@
+# Sync Documents (dev) checkout and %LOCALAPPDATA%\hermes\hermes-agent (managed)
+# to the same origin/<branch> tip, then optionally run `hermes update` + Desktop rebuild.
+#
+# Usage (PowerShell):
+#   .\scripts\windows\Sync-HermesUpdateTrees.ps1
+#   .\scripts\windows\Sync-HermesUpdateTrees.ps1 -RebuildDesktop
+#   .\scripts\windows\Sync-HermesUpdateTrees.ps1 -DocsRoot "D:\src\hermes-agent"
+#
+# Why: Desktop update checks often hit the managed tree while you edit Documents.
+# When those SHAs diverge, Client stays at v0.x (cNNNN) even after a Documents pull.
+
+param(
+    [string]$DocsRoot = "C:\Users\downl\Documents\New project\hermes-agent",
+    [string]$ManagedRoot = "",
+    [string]$Branch = "main",
+    [switch]$RebuildDesktop,
+    [switch]$SkipHermesUpdate,
+    [switch]$SkipStopProcesses
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $ManagedRoot) {
+    if (-not $env:LOCALAPPDATA) {
+        throw "LOCALAPPDATA is empty — run this on native Windows PowerShell."
+    }
+    $ManagedRoot = Join-Path $env:LOCALAPPDATA "hermes\hermes-agent"
+}
+
+function Write-Step([string]$Message) {
+    Write-Host ("[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $Message)
+}
+
+function Assert-GitCheckout([string]$Path) {
+    if (-not (Test-Path -LiteralPath (Join-Path $Path ".git"))) {
+        throw "Not a git checkout: $Path"
+    }
+}
+
+function Get-ShortSha([string]$Path) {
+    Push-Location -LiteralPath $Path
+    try {
+        return (git rev-parse --short HEAD).Trim()
+    } finally {
+        Pop-Location
+    }
+}
+
+function Stop-HermesLockHolders {
+    Write-Step "Stopping Hermes / Electron processes that lock managed files"
+    $names = @("Hermes", "electron", "hermes")
+    foreach ($name in $names) {
+        Get-Process -Name $name -ErrorAction SilentlyContinue | ForEach-Object {
+            Write-Step ("  stop pid={0} name={1}" -f $_.Id, $_.ProcessName)
+            Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+        }
+    }
+    Start-Sleep -Seconds 2
+}
+
+function Sync-GitTree {
+    param(
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $true)][string]$Path,
+        [Parameter(Mandatory = $true)][string]$BranchName
+    )
+
+    Assert-GitCheckout -Path $Path
+    $before = Get-ShortSha -Path $Path
+    Write-Step ("{0}: {1} @ {2}" -f $Label, $Path, $before)
+
+    Push-Location -LiteralPath $Path
+    try {
+        git fetch --quiet origin
+        $current = (git rev-parse --abbrev-ref HEAD).Trim()
+        if ($current -ne $BranchName) {
+            Write-Step ("  checkout {0} (was {1})" -f $BranchName, $current)
+            git checkout $BranchName
+        }
+        git pull --ff-only origin $BranchName
+        if ($LASTEXITCODE -ne 0) {
+            throw ("git pull --ff-only failed in {0}. Resolve local commits/dirty state, then re-run." -f $Path)
+        }
+    } finally {
+        Pop-Location
+    }
+
+    $after = Get-ShortSha -Path $Path
+    Write-Step ("{0}: {1} -> {2}" -f $Label, $before, $after)
+    return $after
+}
+
+Write-Step "=== Sync Hermes update trees (option B) ==="
+Write-Step ("DocsRoot     = {0}" -f $DocsRoot)
+Write-Step ("ManagedRoot  = {0}" -f $ManagedRoot)
+Write-Step ("Branch       = {0}" -f $Branch)
+
+if (-not (Test-Path -LiteralPath $DocsRoot)) {
+    throw "DocsRoot not found: $DocsRoot"
+}
+if (-not (Test-Path -LiteralPath $ManagedRoot)) {
+    throw "ManagedRoot not found: $ManagedRoot (install Hermes first, or pass -ManagedRoot)"
+}
+
+if (-not $SkipStopProcesses) {
+    Stop-HermesLockHolders
+}
+
+$docsSha = Sync-GitTree -Label "Documents" -Path $DocsRoot -BranchName $Branch
+$managedSha = Sync-GitTree -Label "LOCALAPPDATA" -Path $ManagedRoot -BranchName $Branch
+
+if (-not $SkipHermesUpdate) {
+    $hermesCmd = Get-Command hermes -ErrorAction SilentlyContinue
+    if ($hermesCmd) {
+        Write-Step "Running: hermes update"
+        & hermes update
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "hermes update exited with code $LASTEXITCODE — check output above"
+        }
+    } else {
+        Write-Warning "hermes not on PATH — skipped hermes update. Open a new shell after install, or run from managed venv."
+    }
+}
+
+if ($RebuildDesktop) {
+    $desktopDir = Join-Path $ManagedRoot "apps\desktop"
+    if (-not (Test-Path -LiteralPath $desktopDir)) {
+        throw "Desktop package missing: $desktopDir"
+    }
+    Write-Step "Rebuilding Desktop in managed tree"
+    Push-Location -LiteralPath $ManagedRoot
+    try {
+        npm install
+        if ($LASTEXITCODE -ne 0) { throw "npm install failed at repo root" }
+    } finally {
+        Pop-Location
+    }
+    Push-Location -LiteralPath $desktopDir
+    try {
+        npm run build
+        if ($LASTEXITCODE -ne 0) { throw "npm run build failed in apps/desktop" }
+    } finally {
+        Pop-Location
+    }
+}
+
+$docsFinal = Get-ShortSha -Path $DocsRoot
+$managedFinal = Get-ShortSha -Path $ManagedRoot
+
+Write-Host ""
+Write-Step "=== Result ==="
+Write-Host ("  Documents    : {0}" -f $docsFinal)
+Write-Host ("  LOCALAPPDATA : {0}" -f $managedFinal)
+
+if ($docsFinal -ne $managedFinal) {
+    Write-Warning "SHAs still differ. Check remotes (origin URL) and local dirty commits."
+    exit 2
+}
+
+Write-Step "Trees match. Restart Hermes Desktop (packaged Hermes.exe or hermes desktop)."
+Write-Host "  Packaged tip: $env:LOCALAPPDATA\hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe"
+exit 0

--- a/scripts/windows/Sync-HermesUpdateTrees.ps1
+++ b/scripts/windows/Sync-HermesUpdateTrees.ps1
@@ -157,6 +157,13 @@ if ($docsFinal -ne $managedFinal) {
     exit 2
 }
 
-Write-Step "Trees match. Restart Hermes Desktop (packaged Hermes.exe or hermes desktop)."
-Write-Host "  Packaged tip: $env:LOCALAPPDATA\hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe"
+Write-Step "Trees match. Retarget Desktop shortcuts to Documents (source launch)."
+$retarget = Join-Path $PSScriptRoot "Retarget-HermesDesktopShortcut.ps1"
+if (Test-Path -LiteralPath $retarget) {
+    & powershell -NoProfile -ExecutionPolicy Bypass -File $retarget -RepoRoot $DocsRoot
+}
+else {
+    Write-Warning "Retarget script missing — run scripts\windows\Retarget-HermesDesktopShortcut.ps1 after pull"
+}
+Write-Step "Restart via Desktop\Hermes.lnk (not the old LOCALAPPDATA Hermes.exe)."
 exit 0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

#45 のツリー同期だけでは足りない。ショートカットが `%LOCALAPPDATA%\...\Hermes.exe` を指したままだと、Documents を最新にしても Client `cNNNN` が残る（`npm run build` は packaged exe を更新しない）。

## Changes

- `Retarget-HermesDesktopShortcut.ps1` — Desktop の Hermes.lnk を Documents の `start-hermes-desktop.ps1` 起動に書き換え
- `create-hermes-desktop-shortcuts.ps1` — 非 managed checkout では source 起動を優先
- `Sync-HermesUpdateTrees.ps1` — 同期成功後に Retarget を呼ぶ

## Test plan

- [ ] PowerShell で Retarget 実行 → Desktop\Hermes.lnk が powershell + start-hermes-desktop.ps1
- [ ] 起動後 Client `(cNNNN)` が消える／減る
- [ ] managed ルートから shortcuts 作成時は packaged exe のまま
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f21971bc-3bfb-4192-8d41-cc830d4d41e5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

