### PR TITLE
fix(memory): accept existing ISO timestamps in graph bridge

### DIFF
--- a/plugins/memory/ebbinghaus/semantic_graph_bridge.py
+++ b/plugins/memory/ebbinghaus/semantic_graph_bridge.py
@@ -17,7 +17,7 @@ from plugins.semantic_graph.sanitize import normalize_text, sanitize_text
 from plugins.semantic_graph.store import SemanticGraphStore
 
 from .policies import EbbinghausPolicies, is_protected
-from .store import EbbinghausMemoryStore, _dream_idempotency_key
+from .store import EbbinghausMemoryStore, _dream_idempotency_key, _timestamp_value
 
 logger = logging.getLogger(__name__)
 
@@ -274,7 +274,7 @@ class EbbinghausSemanticGraphBridge:
                 tags,
                 memory_store.policies.capacity.protected_tags,
             ),
-            "source_updated_at": float(raw.get("updated_at") or 0.0),
+            "source_updated_at": _timestamp_value(raw.get("updated_at")),
             "synced_at": float(synced_at),
         }
 

--- a/tests/plugins/test_ebbinghaus_semantic_graph_bridge.py
+++ b/tests/plugins/test_ebbinghaus_semantic_graph_bridge.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -447,6 +448,31 @@ def test_sync_dry_run_has_zero_mutation_and_apply_is_idempotent(tmp_path: Path) 
         assert second["synced"] == 2
         assert graph.get_status_counts()["memory_node_links"] == 2
         assert graph.get_status_counts()["memory_state_cache"] == 2
+    finally:
+        memory.close()
+
+
+def test_sync_accepts_existing_iso_updated_at_rows(tmp_path: Path) -> None:
+    memory, graph, bridge = _bridge(tmp_path)
+    try:
+        remembered = memory.remember("Existing timestamp compatibility")
+        updated_at = "2026-08-11T15:55:16.787970+00:00"
+        memory._conn.execute(  # noqa: SLF001 - seed an existing live row shape
+            "UPDATE memories SET updated_at = ? WHERE memory_id = ?",
+            (updated_at, remembered["memory_id"]),
+        )
+        memory._conn.commit()  # noqa: SLF001
+
+        result = bridge.sync(limit=1, dry_run=False)
+
+        assert result["success"] is True
+        assert result["synced"] == 1
+        assert result["failed"] == 0
+        cache = graph.get_memory_state_cache(remembered["memory_id"])
+        assert cache is not None
+        assert cache["source_updated_at"] == pytest.approx(
+            datetime.fromisoformat(updated_at).timestamp()
+        )
     finally:
         memory.close()
 


### PR DESCRIPTION
## Summary

- accept the existing Ebbinghaus ISO-8601 `updated_at` representation when projecting memory state into Semantic Graph
- reuse the store's existing `_timestamp_value()` compatibility converter
- add one regression test matching the live row shape

## Architecture boundaries

This is a two-line production compatibility fix plus one focused test. It does not change retrieval ordering, Ebbinghaus decay, graph confidence, belief status, embedding serialization, schema, configuration, dependencies, server lifecycle, or active rollout gates.

## Reproduction

The shadow rollout's first bounded `cognitive-sync --limit 16 --apply` rolled back all graph transactions and recorded 16 repair-pending events with one shared error hash. A SQLite-backup-only reproduction identified an ISO-8601 `updated_at` value reaching a direct `float()` conversion. No memory content or live database value is included here.

## Tests

- RED: targeted compatibility test, `1 failed`
- GREEN: targeted compatibility test, `1 passed`
- bridge file: `12 passed`
- full memory/Semantic Graph focus: `303 passed, 2 skipped`
- ruff: pass
- py_compile: pass
- git diff --check: pass
- Windows footguns: pass, 2 files scanned
- SQLite-backup-only repair proof: 16/16 repaired, 0 failed, repeat 0 pending, both copied DB integrity checks `ok`

## Rollout state

Production remains in cognitive shadow mode with abstention disabled. Phase 5 active acceptance remains HOLD. Live repair will run only after this PR is green and merged.

## Safety

No user-memory content, embedding vectors, secrets, or model reasoning are persisted in test artifacts or reported by this PR. The dirty parent checkout, Desktop, generation port 8080, TurboCUDA, and TurboQuant are untouched.