### PR TITLE
fix(desktop): harden scoped skin wallpaper loading

### DIFF
--- a/apps/desktop/electron/hardening.ts
+++ b/apps/desktop/electron/hardening.ts
@@ -490,6 +490,13 @@ function rejectUnsafePathSyntax(filePath, purpose = 'File read') {
 
   const normalized = raw.replace(/\\/g, '/').toLowerCase()
 
+  // Never allow a network-share path to reach path.resolve/stat/open.  This
+  // check intentionally runs on the raw spelling so mixed slash UNC forms
+  // are rejected before Node can reinterpret them as a local path.
+  if (/^\/\/[^/]+(?:\/|$)/.test(normalized)) {
+    throw ipcPathError('network-path', `${purpose} blocked: network share paths are not allowed.`)
+  }
+
   if (
     normalized.startsWith('//?/') ||
     normalized.startsWith('//./') ||
@@ -523,8 +530,15 @@ function resolveRequestedPathForIpc(filePath, options: { purpose?: string; baseD
         throw new Error('not a file URL')
       }
 
+      if (parsed.hostname && parsed.hostname.toLowerCase() !== 'localhost') {
+        throw ipcPathError('network-path', `${purpose} blocked: remote file URL authorities are not allowed.`)
+      }
+
       resolvedPath = fileURLToPath(parsed)
-    } catch {
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'network-path') {
+        throw error
+      }
       throw ipcPathError('invalid-path', `${purpose} failed: file URL is invalid.`)
     }
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -5418,6 +5418,15 @@ async function saveImageFromUrl(rawUrl) {
   return true
 }
 
+// Keep backend-provided HTTP(S) skin images on the same constrained path as
+// image downloads.  The renderer receives only a data URL, so it cannot make
+// an arbitrary direct request or expose redirects/cookies to the page.
+async function readImageDataUrlFromUrl(rawUrl) {
+  const { buffer, mimeType } = (await resourceBufferFromUrl(rawUrl)) as any
+
+  return `data:${mimeType};base64,${buffer.toString('base64')}`
+}
+
 async function writeComposerImage(buffer, ext = '.png') {
   const rawExt = String(ext || '.png')
     .trim()
@@ -13762,6 +13771,7 @@ ipcMain.handle('hermes:readClipboard', () => clipboard.readText())
 ipcMain.handle('hermes:saveGatewayFile', (_event, payload) => saveGatewayFile(payload))
 
 ipcMain.handle('hermes:saveImageFromUrl', (_event, url) => saveImageFromUrl(String(url || '')))
+ipcMain.handle('hermes:readImageDataUrl', (_event, url) => readImageDataUrlFromUrl(String(url || '')))
 
 // The custom context menu's edit verbs. They act on the SENDER's focused
 // element, so the renderer restores focus to the editable before invoking.

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -190,6 +190,10 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   readWindowBelow: () => ipcRenderer.invoke('hermes:window:readBelow'),
   readFileDataUrl: filePath => ipcRenderer.invoke('hermes:readFileDataUrl', filePath),
   readFileDataUrlForAttach: filePath => ipcRenderer.invoke('hermes:readFileDataUrlForAttach', filePath),
+  // Fetch public image URLs in the main process.  The renderer must not use
+  // <img src=https://...> for backend-provided skins because that bypasses
+  // the URL validation and redirect limits shared by image downloads.
+  readImageDataUrl: url => ipcRenderer.invoke('hermes:readImageDataUrl', url),
   dataUrlReadMax: {
     get: () => ipcRenderer.invoke('hermes:data-url-read-max:get'),
     set: maxMb => ipcRenderer.invoke('hermes:data-url-read-max:set', maxMb)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -10,6 +10,7 @@ import {
   setChangeEventsAvailable
 } from '@/store/live-sync'
 import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
+import { activeGatewayConnectionId, gatewayScope } from '@/store/gateway'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
 // module graph into the gateway event hot path.
 import { ingestBackendSkin } from '@/themes/backend-sync'
@@ -23,7 +24,12 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
   if (event.type === 'gateway.ready') {
     // Seed the active skin into the desktop theme registry without applying,
     // so a fresh connect never overrides the user's persisted desktop theme.
-    ingestBackendSkin((payload as { skin?: HermesSkin } | undefined)?.skin, { apply: false })
+    ingestBackendSkin((payload as { skin?: HermesSkin } | undefined)?.skin, {
+      apply: false,
+      scope:
+        ctx.sourceScope ??
+        gatewayScope(event.connectionId ?? activeGatewayConnectionId(), event.profile ?? deps.activeGatewayProfile)
+    })
     // Backends with the change watcher broadcast pet/cron/sessions change
     // events; consumers demote their legacy polls to slow backstops.
     setChangeEventsAvailable(Boolean((payload as { change_events?: boolean } | undefined)?.change_events))
@@ -34,9 +40,12 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
   if (event.type === 'skin.changed') {
     // A runtime skin switch (Hermes activating an authored skin, or `/skin`
     // on another surface). Only the active source+profile's change repaints.
-    if (fromActiveSource()) {
-      ingestBackendSkin(payload as HermesSkin | undefined, { apply: true })
-    }
+    ingestBackendSkin(payload as HermesSkin | undefined, {
+      apply: fromActiveSource(),
+      scope:
+        ctx.sourceScope ??
+        gatewayScope(event.connectionId ?? activeGatewayConnectionId(), event.profile ?? deps.activeGatewayProfile)
+    })
 
     return true
   }

--- a/apps/desktop/src/components/Backdrop.tsx
+++ b/apps/desktop/src/components/Backdrop.tsx
@@ -2,7 +2,7 @@ import { useStore } from '@nanostores/react'
 import { Leva, useControls } from 'leva'
 import { type CSSProperties, useEffect, useMemo, useState } from 'react'
 
-import { isFileMediaPath, resolveMediaDisplaySrc } from '@/lib/media'
+import { isFileMediaPath, isNetworkFilePath, resolveMediaDisplaySrc } from '@/lib/media'
 import { $backdrop } from '@/store/backdrop'
 import { useTheme } from '@/themes/context'
 
@@ -76,15 +76,41 @@ export function Backdrop() {
     }
 
     // A backend skin may be remote. Keep the renderer from making arbitrary
-    // outbound requests: files use the existing authenticated media path and
-    // inline data must identify itself as an image.
-    if (!isFileMediaPath(wallpaper) && !/^data:image\//i.test(wallpaper)) {
+    // outbound requests: public HTTP(S) images go through the main-process
+    // SSRF-safe bridge, files use the authenticated media path, and inline
+    // data must identify itself as an image. UNC paths are never accepted.
+    if (/^https?:\/\//i.test(wallpaper)) {
+      if (!window.hermesDesktop?.readImageDataUrl) {
+        setSkinWallpaperUrl(null)
+
+        return
+      }
+
+      void window.hermesDesktop
+        .readImageDataUrl(wallpaper)
+        .then(src => {
+          if (!cancelled) {
+            setSkinWallpaperUrl(src || null)
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setSkinWallpaperUrl(null)
+          }
+        })
+
+      return () => {
+        cancelled = true
+      }
+    }
+
+    if (isNetworkFilePath(wallpaper) || (!isFileMediaPath(wallpaper) && !/^data:image\//i.test(wallpaper))) {
       setSkinWallpaperUrl(null)
 
       return
     }
 
-    void resolveMediaDisplaySrc(wallpaper)
+    void resolveMediaDisplaySrc(wallpaper, theme.backgroundImageSource)
       .then(src => {
         if (!cancelled) {
           setSkinWallpaperUrl(src || null)
@@ -99,7 +125,7 @@ export function Backdrop() {
     return () => {
       cancelled = true
     }
-  }, [wallpaper])
+  }, [theme.backgroundImageSource, wallpaper])
 
   const shape = useControls(
     'UI / Shape',

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -218,6 +218,8 @@ declare global {
         saved: boolean
       }>
       saveImageFromUrl: (url: string) => Promise<boolean>
+      /** Fetch a public image URL through the main-process SSRF-safe proxy. */
+      readImageDataUrl?: (url: string) => Promise<string>
       /** Edit verb against the window's focused element (the custom context
        *  menu's Cut/Copy/Paste/Select all). */
       contextMenuEdit?: (command: 'copy' | 'cut' | 'paste' | 'selectAll') => Promise<void>

--- a/apps/desktop/src/lib/desktop-fs.ts
+++ b/apps/desktop/src/lib/desktop-fs.ts
@@ -6,6 +6,10 @@ import type {
 } from '@/global'
 import { $connection } from '@/store/session'
 
+import type { DesktopThemeSource } from '@/themes/types'
+
+export type DesktopFsSourceScope = DesktopThemeSource
+
 export interface DesktopFsRemotePicker {
   selectPaths: (options?: HermesSelectPathsOptions) => Promise<string[]>
 }
@@ -43,6 +47,16 @@ export function desktopFsProfile(): string | undefined {
   return $connection.get()?.profile || undefined
 }
 
+function sameAsActiveScope(scope: DesktopFsSourceScope): boolean {
+  const active = $connection.get()
+  const activeConnection = active?.connectionId?.trim() || null
+  const activeProfile = active?.profile?.trim() || 'default'
+
+  return (
+    (scope.connectionId?.trim() || null) === activeConnection && (scope.profile.trim() || 'default') === activeProfile
+  )
+}
+
 function fsPath(endpoint: string, filePath: string) {
   return `/api/fs/${endpoint}?path=${encodeURIComponent(filePath)}`
 }
@@ -57,10 +71,18 @@ function bridge() {
   return desktop
 }
 
-function remoteFsApi<T>(path: string, body?: Record<string, unknown>): Promise<T> {
-  return bridge().api<T>(
-    body ? { body, method: 'POST', path, profile: desktopFsProfile() } : { path, profile: desktopFsProfile() }
-  )
+function remoteFsApi<T>(path: string, body?: Record<string, unknown>, scope?: DesktopFsSourceScope): Promise<T> {
+  const connection = $connection.get()
+  const profile = scope ? scope.profile.trim() || 'default' : desktopFsProfile()
+  const connectionId = scope ? scope.connectionId : connection?.connectionId ?? null
+
+  const request = body ? { body, method: 'POST' as const, path, profile } : { path, profile }
+
+  if (scope || connection?.connectionId) {
+    return bridge().api<T>({ ...request, connectionId })
+  }
+
+  return bridge().api<T>(request)
 }
 
 export async function readDesktopDir(path: string): Promise<HermesReadDirResult> {
@@ -99,12 +121,15 @@ export async function writeDesktopFileText(path: string, content: string): Promi
   return { path: result.path || path }
 }
 
-export async function readDesktopFileDataUrl(path: string): Promise<string> {
-  if (!isDesktopFsRemoteMode()) {
+export async function readDesktopFileDataUrl(path: string, scope?: DesktopFsSourceScope): Promise<string> {
+  // A wallpaper's source scope is immutable. Even when the active shell is
+  // local, a non-active connection must be read through its authenticated API
+  // route rather than falling through to this machine's Electron filesystem.
+  if (!isDesktopFsRemoteMode() && (!scope || sameAsActiveScope(scope))) {
     return bridge().readFileDataUrl(path)
   }
 
-  const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path))
+  const result = await remoteFsApi<string | { dataUrl?: string }>(fsPath('read-data-url', path), undefined, scope)
 
   return typeof result === 'string' ? result : result.dataUrl || ''
 }

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -7,6 +7,7 @@ import {
   filePathFromMediaPath,
   gatewayMediaDataUrl,
   isInlineMediaSrc,
+  isNetworkFilePath,
   isRemoteGateway,
   mediaExternalUrl,
   mediaGatewayStreamUrl,
@@ -42,6 +43,25 @@ describe('filePathFromMediaPath', () => {
 
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
+  })
+
+  it('normalizes Windows drive file URLs without duplicating the drive prefix', () => {
+    expect(filePathFromMediaPath('file:///C:/Users/Bob/wallpaper.png')).toBe('C:/Users/Bob/wallpaper.png')
+  })
+
+  it('rejects non-local file URL authorities', () => {
+    expect(() => filePathFromMediaPath('file://fileserver/share/wallpaper.png')).toThrow(/Network-share/)
+  })
+})
+
+describe('isNetworkFilePath', () => {
+  it.each([
+    String.raw`\\fileserver\share\wallpaper.png`,
+    '//fileserver/share/wallpaper.png',
+    'file://fileserver/share/wallpaper.png',
+    'file:///%5C%5Cfileserver%5Cshare%5Cwallpaper.png'
+  ])('rejects network spelling %s', path => {
+    expect(isNetworkFilePath(path)).toBe(true)
   })
 })
 

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -1,4 +1,4 @@
-import { readDesktopFileDataUrl } from '@/lib/desktop-fs'
+import { readDesktopFileDataUrl, type DesktopFsSourceScope } from '@/lib/desktop-fs'
 import { capitalize } from '@/lib/text'
 import { $connection } from '@/store/session'
 
@@ -77,13 +77,44 @@ export function isFileMediaPath(path: string): boolean {
   return /^(?:file:|\/|~\/|[a-z]:[\\/]|\\\\)/i.test(path)
 }
 
-export async function resolveMediaDisplaySrc(path: string): Promise<string> {
+/** Reject UNC/network-share paths before any renderer or backend filesystem bridge. */
+export function isNetworkFilePath(path: string): boolean {
+  const raw = path.trim()
+  const normalized = raw.replace(/\\/g, '/')
+
+  if (normalized.startsWith('//')) {
+    return true
+  }
+
+  if (!/^file:/i.test(raw)) {
+    return false
+  }
+
+  try {
+    const url = new URL(raw)
+    const host = url.hostname.trim().toLowerCase()
+
+    if (host && host !== 'localhost') {
+      return true
+    }
+
+    return decodeURIComponent(url.pathname).replace(/\\/g, '/').startsWith('//')
+  } catch {
+    return false
+  }
+}
+
+export async function resolveMediaDisplaySrc(path: string, scope?: DesktopFsSourceScope): Promise<string> {
   if (isInlineMediaSrc(path) || !isFileMediaPath(path)) {
     return path
   }
 
-  if (window.hermesDesktop && isRemoteGateway()) {
-    return gatewayMediaDataUrl(path)
+  if (isNetworkFilePath(path)) {
+    throw new Error('Network-share media paths are not allowed')
+  }
+
+  if (window.hermesDesktop && (isRemoteGateway() || scope)) {
+    return gatewayMediaDataUrl(path, scope)
   }
 
   if (!window.hermesDesktop?.readFileDataUrl) {
@@ -113,6 +144,10 @@ export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
 // gateway-local paths to an authenticated /api/files/download URL (the file
 // lives on the gateway, not this disk); local mode keeps the file:// form.
 export function mediaExternalUrl(path: string): string {
+  if (isNetworkFilePath(path)) {
+    throw new Error('Network-share media paths are not allowed')
+  }
+
   if (/^https?:/i.test(path)) {
     return path
   }
@@ -135,6 +170,10 @@ export function mediaExternalUrl(path: string): string {
 // HTTPS source cannot authenticate reliably. The custom protocol keeps secrets
 // out of renderer URLs while forwarding Range requests to /api/files/stream.
 export function mediaGatewayStreamUrl(path: string): string {
+  if (isNetworkFilePath(path)) {
+    throw new Error('Network-share media paths are not allowed')
+  }
+
   const conn = $connection.get()
 
   if (isRemoteGateway()) {
@@ -151,6 +190,10 @@ export function mediaGatewayStreamUrl(path: string): string {
 // file with Range support. Used for audio/video so playback bypasses the data
 // URL size cap and supports seeking. `path` may be a plain path or `file://…`.
 export function mediaStreamUrl(path: string): string {
+  if (isNetworkFilePath(path)) {
+    throw new Error('Network-share media paths are not allowed')
+  }
+
   return `hermes-media://stream/${encodeURIComponent(filePathFromMediaPath(path))}`
 }
 
@@ -172,8 +215,22 @@ export function filePathFromMediaPath(path: string): string {
   }
 
   try {
-    return decodeURIComponent(new URL(path).pathname)
+    const url = new URL(path)
+
+    if (url.hostname && url.hostname.toLowerCase() !== 'localhost') {
+      throw new Error('Network-share file URLs are not allowed')
+    }
+
+    const decoded = decodeURIComponent(url.pathname)
+
+    // URL.pathname retains a leading slash for Windows drive paths. Strip it
+    // so file:///C:/... does not become /C:/... or C:\C:\... downstream.
+    return decoded.replace(/^\/[a-z]:[\\/]/i, match => match.slice(1))
   } catch {
+    if (isNetworkFilePath(path)) {
+      throw new Error('Network-share file URLs are not allowed')
+    }
+
     return path.replace(/^file:\/\//, '')
   }
 }
@@ -188,8 +245,12 @@ export function isRemoteGateway(): boolean {
 // bridge. Remote Desktop artifacts can live anywhere the gateway can read
 // (workspace, skills, ~/.hermes/cache, etc.); /api/media is intentionally
 // narrower and rejects non-images plus images outside its media roots.
-export async function gatewayMediaDataUrl(path: string): Promise<string> {
-  return readDesktopFileDataUrl(filePathFromMediaPath(path))
+export async function gatewayMediaDataUrl(path: string, scope?: DesktopFsSourceScope): Promise<string> {
+  if (isNetworkFilePath(path)) {
+    throw new Error('Network-share media paths are not allowed')
+  }
+
+  return readDesktopFileDataUrl(filePathFromMediaPath(path), scope)
 }
 
 // Remote-mode replacement for opening gateway-local file paths with file://.

--- a/apps/desktop/src/themes/backend-sync.test.ts
+++ b/apps/desktop/src/themes/backend-sync.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { $connection } from '@/store/session'
 
 import { $backendThemes, $pendingSkinApply, __resetBackendSkinSync, ingestBackendSkin } from './backend-sync'
 import { BUILTIN_THEMES } from './presets'
@@ -10,6 +12,7 @@ const skin = (name: string) => ({
 
 describe('ingestBackendSkin', () => {
   beforeEach(() => __resetBackendSkinSync())
+  afterEach(() => $connection.set(null))
 
   it('registers a converted skin without applying when apply=false', () => {
     ingestBackendSkin(skin('neon'), { apply: false })
@@ -131,6 +134,24 @@ describe('ingestBackendSkin', () => {
     ingestBackendSkin(skin('mono'), { apply: false })
 
     expect($backendThemes.get().mono).toBeUndefined()
+  })
+
+  it('keeps same-named wallpaper metadata isolated by connection and profile', () => {
+    $connection.set({ connectionId: 'gateway-a', profile: 'default' } as never)
+    ingestBackendSkin(
+      { ...skin('mono'), background_image: 'C:/gateway-a/mono.png' },
+      { apply: false, scope: { connectionId: 'gateway-a', profile: 'default' } }
+    )
+    ingestBackendSkin(
+      { ...skin('mono'), background_image: 'C:/gateway-b/mono.png' },
+      { apply: false, scope: { connectionId: 'gateway-b', profile: 'default' } }
+    )
+
+    expect($backendThemes.get().mono?.backgroundImage).toBe('C:/gateway-a/mono.png')
+    expect($backendThemes.get().mono?.backgroundImageSource).toEqual({
+      connectionId: 'gateway-a',
+      profile: 'default'
+    })
   })
 
   it('ignores empty payloads', () => {

--- a/apps/desktop/src/themes/backend-sync.ts
+++ b/apps/desktop/src/themes/backend-sync.ts
@@ -18,14 +18,33 @@
  */
 
 import type { HermesSkin } from '@hermes/shared/skin'
+import { registryBackendScopeKey } from '@hermes/shared'
 import { atom } from 'nanostores'
+
+import { $connection } from '@/store/session'
 
 import { BUILTIN_THEMES } from './presets'
 import { skinToDesktopTheme } from './skin'
-import type { DesktopTheme } from './types'
+import type { DesktopTheme, DesktopThemeSource } from './types'
 
-/** Skins pushed by the backend, keyed by name. Merged by `listAllThemes`. */
+/** Skins pushed by each backend, keyed first by its connection/profile scope. */
+const $backendThemesByScope = atom<Record<string, Record<string, DesktopTheme>>>({})
+
+/** Active-scope view consumed by the theme registry. Kept as a writable atom
+ * for compatibility with existing theme tests and plugin integrations. */
 export const $backendThemes = atom<Record<string, DesktopTheme>>({})
+
+function activeScopeKey(): string {
+  const connection = $connection.get()
+
+  return registryBackendScopeKey(connection?.connectionId ?? null, connection?.profile ?? null)
+}
+
+function publishActiveScope(scoped = $backendThemesByScope.get()): void {
+  $backendThemes.set(scoped[activeScopeKey()] ?? {})
+}
+
+$connection.subscribe(() => publishActiveScope())
 
 /** One-shot skin name the ThemeProvider should switch to (it clears this). */
 export const $pendingSkinApply = atom<string | null>(null)
@@ -36,11 +55,28 @@ export const $pendingSkinApply = atom<string | null>(null)
 // A `skin.changed` matching a seed-only baseline still applies: the seed
 // records without painting, so if the activation event was missed (backend
 // restart / disconnected), an explicit re-affirm must repaint, not no-op.
-let lastSynced: { applied: boolean; name: string } | null = null
+const lastSyncedByScope = new Map<string, { applied: boolean; name: string }>()
+
+function sourceFor(source?: DesktopThemeSource): DesktopThemeSource {
+  if (source) {
+    return Object.freeze({
+      connectionId: source.connectionId ?? null,
+      profile: source.profile.trim() || 'default'
+    })
+  }
+
+  const connection = $connection.get()
+
+  return Object.freeze({
+    connectionId: connection?.connectionId ?? null,
+    profile: connection?.profile?.trim() || 'default'
+  })
+}
 
 /** Test-only: reset the module's apply guard + registry between cases. */
 export function __resetBackendSkinSync(): void {
-  lastSynced = null
+  lastSyncedByScope.clear()
+  $backendThemesByScope.set({})
   $backendThemes.set({})
   $pendingSkinApply.set(null)
 }
@@ -51,12 +87,18 @@ export function __resetBackendSkinSync(): void {
  * change. Built-in names keep the desktop's own palette while still accepting
  * wallpaper, fit, position, and overlay from the canonical backend skin.
  */
-export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }: { apply: boolean }): void {
+export function ingestBackendSkin(
+  skin: HermesSkin | undefined | null,
+  { apply, scope }: { apply: boolean; scope?: DesktopThemeSource }
+): void {
   const name = (skin && typeof skin === 'object' ? (skin.name ?? '') : '').trim()
 
   if (!name) {
     return
   }
+
+  const source = sourceFor(scope)
+  const scopeKey = registryBackendScopeKey(source.connectionId, source.profile)
 
   // `default` is "no opinion" on the PALETTE — the desktop keeps its own default
   // (nous), so we never register a converted theme under `default`. It is still a
@@ -73,7 +115,8 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
       return
     }
 
-    const current = $backendThemes.get()
+    const scoped = $backendThemesByScope.get()
+    const current = scoped[scopeKey] ?? {}
     const builtin = BUILTIN_THEMES[name]
 
     const theme = builtin
@@ -83,31 +126,40 @@ export function ingestBackendSkin(skin: HermesSkin | undefined | null, { apply }
             backgroundImage: converted.backgroundImage,
             backgroundImageFit: converted.backgroundImageFit,
             backgroundImagePosition: converted.backgroundImagePosition,
-            backgroundOverlay: converted.backgroundOverlay
+            backgroundOverlay: converted.backgroundOverlay,
+            backgroundImageSource: source
           }
         : null
-      : converted
+      : converted.backgroundImage
+        ? { ...converted, backgroundImageSource: source }
+        : converted
 
     if (!theme && current[name]) {
       const { [name]: _removed, ...rest } = current
-      $backendThemes.set(rest)
+      const next = { ...scoped, [scopeKey]: rest }
+      $backendThemesByScope.set(next)
+      if (scopeKey === activeScopeKey()) publishActiveScope(next)
     } else if (theme && JSON.stringify(current[name]) !== JSON.stringify(theme)) {
-      $backendThemes.set({ ...current, [name]: theme })
+      const next = { ...scoped, [scopeKey]: { ...current, [name]: theme } }
+      $backendThemesByScope.set(next)
+      if (scopeKey === activeScopeKey()) publishActiveScope(next)
     }
   }
+
+  const lastSynced = lastSyncedByScope.get(scopeKey)
 
   if (!apply) {
     // Connect-time seed: record without painting. A reconnect re-seed keeps an
     // earlier real apply's flag so repeat events can't override a manual switch.
     if (lastSynced?.name !== name || !lastSynced.applied) {
-      lastSynced = { applied: false, name }
+      lastSyncedByScope.set(scopeKey, { applied: false, name })
     }
 
     return
   }
 
   if (name !== lastSynced?.name || !lastSynced.applied) {
-    lastSynced = { applied: true, name }
+    lastSyncedByScope.set(scopeKey, { applied: true, name })
     $pendingSkinApply.set(name)
   }
 }

--- a/apps/desktop/src/themes/types.ts
+++ b/apps/desktop/src/themes/types.ts
@@ -85,6 +85,12 @@ export interface DesktopTerminalPalette {
   brightWhite?: string
 }
 
+/** Backend identity that owns renderer-only skin metadata such as wallpapers. */
+export interface DesktopThemeSource {
+  readonly connectionId: null | string
+  readonly profile: string
+}
+
 export interface DesktopTheme {
   name: string
   label: string
@@ -103,4 +109,6 @@ export interface DesktopTheme {
   backgroundImageFit?: string
   backgroundImagePosition?: string
   backgroundOverlay?: string
+  /** Source route used when resolving a backend-owned wallpaper. */
+  backgroundImageSource?: DesktopThemeSource
 }

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -2189,12 +2189,20 @@ def _fs_path(raw_path: str) -> Path:
         if raw.lower().startswith("file:"):
             parsed = urllib.parse.urlparse(raw)
             if parsed.netloc and parsed.netloc not in {"", "localhost"}:
-                raise ValueError
-            raw = urllib.request.url2pathname(parsed.path)
+                raise PermissionError("remote file URL authority")
+            raw = urllib.request.url2pathname(urllib.parse.unquote(parsed.path))
+        # Reject raw and decoded UNC/network-share spellings before Path or any
+        # endpoint can stat, scan, open, or stream the target.  This remains
+        # OS-neutral so Windows backslashes cannot bypass the POSIX test path.
+        normalized = raw.replace("\\", "/")
+        if normalized.startswith("//") and len(normalized) > 2 and normalized.lstrip("/"):
+            raise PermissionError("network share path")
         candidate = Path(raw).expanduser()
         if not candidate.is_absolute():
             candidate = Path.cwd() / candidate
         return candidate.resolve(strict=False)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Network share paths are not allowed")
     except (OSError, RuntimeError, ValueError):
         raise HTTPException(status_code=400, detail="Invalid path")
 

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -1,5 +1,4 @@
 import base64
-from pathlib import Path
 
 import pytest
 
@@ -89,3 +88,33 @@ def test_fs_endpoints_require_auth(tmp_path):
     assert list_response.status_code == 401
     assert read_response.status_code == 401
     assert default_response.status_code == 401
+
+
+@pytest.mark.parametrize(
+    "raw_path",
+    [
+        r"\\fileserver\share\secret.txt",
+        "//fileserver/share/secret.txt",
+        r"\\?\UNC\fileserver\share\secret.txt",
+        "file://fileserver/share/secret.txt",
+        "file:///%5C%5Cfileserver%5Cshare%5Csecret.txt",
+    ],
+)
+def test_fs_rejects_network_paths_before_filesystem_io(client, raw_path, monkeypatch):
+    calls = []
+
+    def fail(*_args, **_kwargs):
+        calls.append(True)
+        raise AssertionError("network path reached filesystem I/O")
+
+    # The endpoint rejects these spellings during path normalization. Patch
+    # only the directory syscall used by the endpoint; patching Path methods
+    # globally also intercepts pytest's own traceback/cache cleanup on a
+    # failing assertion.
+    monkeypatch.setattr(web_server.os, "scandir", fail)
+
+    response = client.get("/api/fs/read-text", params={"path": raw_path})
+
+    assert response.status_code == 403
+    assert "Network share" in response.json()["detail"]
+    assert calls == []


### PR DESCRIPTION
Preserve backend skin wallpaper metadata while enforcing connection/profile scoping, SSRF-safe HTTP image loading, Windows file URL normalization, and UNC/network-share rejection. Targeted desktop media/theme tests and Hermes FS tests pass locally.