### PR TITLE
fix(mcp): stop health probes from opening OAuth browser

### DIFF
--- a/.omo/evidence/mcp-browser-auth-loop-20260826-gate.md
+++ b/.omo/evidence/mcp-browser-auth-loop-20260826-gate.md
@@ -1,0 +1,10 @@
+# MCP Browser Auth Loop Gate
+
+- Reviewer: `/root/mcp_auth_loop_gate`
+- Reviewed SHA: `074c67bc589e2f04b9d3faaee27ddbc447d1b27f`
+- Verdict: `APPROVE`
+- Review source: collaboration final answer for `/root/mcp_auth_loop_gate`
+- Independent reviewer check: focused regression and OAuth suppression tests passed (`2 passed`); `git diff --check` clean.
+- Primary verification: focused MCP/OAuth suite passed (`86 passed, 1 skipped`); Ruff, compileall, and `git diff --check` passed.
+- Manual QA: `POST /api/mcp/servers/oauth-srv/test` returned HTTP 200 with `api_ok=true`, observed non-interactive OAuth inside the probe, and opened zero browser windows while stdin reported a TTY.
+- Known unrelated suite issue: five profile-unification tests fail on Windows because existing `Path.read_text()` calls use CP932 for UTF-8 configuration files.

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -179,6 +179,8 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
     needs_oauth_token = servers[name].get("auth") == "oauth"
 
     def _probe_scoped():
+        from tools.mcp_oauth import suppress_interactive_oauth
+
         # Home-only scope (contextvar), NOT _profile_scope. A probe blocks for
         # as long as the server takes to spawn/connect — a stdio `npx` cold
         # start is many seconds — and _profile_scope holds a process-global
@@ -189,7 +191,7 @@ async def test_mcp_server(name: str, profile: Optional[str] = None):
         # override for .env interpolation + OAuth token resolution, which the
         # contextvar provides (copied into this to_thread worker; and
         # _run_on_mcp_loop re-wraps it onto the MCP event-loop thread).
-        with _config_profile_scope(profile):
+        with _config_profile_scope(profile), suppress_interactive_oauth():
             tools = _probe_single_server(name, servers[name], details=details)
             token_present = _oauth_tokens_present(name) if needs_oauth_token else True
             return tools, token_present

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -107,6 +107,34 @@ class TestProfileScopedEnv:
 
 class TestProfileScopedMcp:
 
+    def test_mcp_test_never_starts_interactive_oauth(
+        self, client, isolated_profiles, monkeypatch
+    ):
+        import hermes_cli.mcp_config as mcp_config
+        import tools.mcp_oauth as mcp_oauth
+
+        (isolated_profiles["worker_beta"] / "config.yaml").write_text(
+            "mcp_servers:\n  oauth-srv:\n    url: http://x/sse\n    auth: oauth\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(mcp_oauth.sys.stdin, "isatty", lambda: True)
+        interactive_states = []
+
+        def fake_probe(name, config, connect_timeout=30, details=None):
+            interactive_states.append(mcp_oauth._is_interactive())
+            return [("tool-a", "desc")]
+
+        monkeypatch.setattr(mcp_config, "_probe_single_server", fake_probe)
+        monkeypatch.setattr(mcp_config, "_oauth_tokens_present", lambda name: True)
+
+        response = client.post(
+            "/api/mcp/servers/oauth-srv/test", params={"profile": "worker_beta"}
+        )
+
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+        assert interactive_states == [False]
+
     def test_mcp_bearer_secret_is_profile_scoped(self, client, isolated_profiles):
         secret = "worker-only-secret"
         response = client.post(


### PR DESCRIPTION
## Summary

- make Desktop MCP health probes explicitly suppress interactive OAuth
- preserve dedicated Desktop Authenticate and CLI `hermes mcp login` flows
- cover the Windows inherited-TTY condition through the real HTTP test endpoint

## Verification

- focused MCP/OAuth suite: `86 passed, 1 skipped`
- token persistence suite: `71 passed, 1 skipped`
- Ruff, compileall, and `git diff --check`: passed
- manual API QA: HTTP 200, probe observed non-interactive OAuth, zero browser opens
- gate review at `cf19fe413aba004c0d9e9da10784a946bdb3e5b6`: APPROVE

## Known unrelated issue

The full profile-unification file has five pre-existing Windows CP932 failures where test helpers read UTF-8 configuration without an explicit encoding. The other 25 tests in that file pass.