### PR TITLE
feat(distribution): ship qualified Windows release channel

### DIFF
--- a/.github/workflows/install-e2e-run.yml
+++ b/.github/workflows/install-e2e-run.yml
@@ -88,6 +88,7 @@ jobs:
             --route '${{ inputs.route }}' \
             --install-ref '${{ inputs.install-ref }}'
         env:
+          HERMES_DEV_SANDBOX_UPSTREAM: https://github.com/${{ github.repository }}.git
           # Outside the workspace on purpose: the script creates this directory
           # up front, and an untracked dir inside the repo makes the worktree
           # dirty -- which dev-sandbox reacts to by snapshotting the working

--- a/.github/workflows/install-e2e.yml
+++ b/.github/workflows/install-e2e.yml
@@ -7,9 +7,6 @@ name: Install & Update E2E
 # scripts/dev-sandbox.sh, then applies one update route and requires the
 # checkout to land on this commit with a working `hermes`.
 #
-# The starting versions are chosen at runtime from the official upstream's
-# release tags (scripts/sandbox/pick-release-tags.sh): newest, oldest, and a
-# spread between.  This fork deliberately carries no release tags of its own.
 # A hardcoded list would stop covering the newest release the day after it
 # ships, and would pin an "oldest" that nobody still runs.
 #
@@ -44,8 +41,7 @@ on:
   push:
     tags:
       # Release tags only: the repo also carries backup/* and one-off tags.
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-      - 'v[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+      - 'v*.*.*-win.*'
 
 permissions:
   contents: read
@@ -64,24 +60,17 @@ jobs:
     outputs:
       tags: ${{ steps.pick.outputs.tags }}
     steps:
-      # This job only reads tag names and runs one script, so avoid blobs and
-      # unrelated paths.  The fork has no release tags; fetch the official
-      # upstream tags explicitly below instead of relying on checkout's
-      # origin-only tag behavior.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          filter: blob:none
-          sparse-checkout: scripts/sandbox/pick-release-tags.sh
-          sparse-checkout-cone-mode: false
-      - name: Fetch upstream release tags
-        run: |
-          set -euo pipefail
-          git fetch --force --no-tags https://github.com/NousResearch/hermes-agent.git \
-            '+refs/tags/v*:refs/tags/v*'
+          fetch-depth: 0
       - id: pick
         run: |
           set -euo pipefail
-          tags="$(scripts/sandbox/pick-release-tags.sh --count '${{ inputs.tag-count || 5 }}')"
+          if git tag --list 'v*.*.*-win.*' | grep -q .; then
+            tags="$(scripts/sandbox/pick-release-tags.sh --count '${{ inputs.tag-count || 5 }}')"
+          else
+            tags='["8447bf369a0977b0dadf5c78896e194001dd1584"]'
+          fi
           echo "Testing updates from: $tags"
           echo "tags=$tags" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,213 @@
+name: Windows downstream release
+
+on:
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*-win.*"
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Release channel for a non-publishing qualification run.
+        required: true
+        type: choice
+        default: preview
+        options: [preview, stable]
+      baseline-ref:
+        description: Commit or downstream tag used as the installed upgrade baseline.
+        required: false
+        type: string
+        default: "8447bf369a0977b0dadf5c78896e194001dd1584"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+concurrency:
+  group: windows-release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PYTHONUTF8: "1"
+  UV_VERSION: "0.9.28"
+  BASELINE_FALLBACK_SHA: "8447bf369a0977b0dadf5c78896e194001dd1584"
+
+jobs:
+  build-qualify-release:
+    name: Build, qualify, and publish Windows artifacts
+    runs-on: windows-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.22.0
+          cache: npm
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version-file: scripts/windows/watchdog-go/go.mod
+          cache-dependency-path: scripts/windows/watchdog-go/go.sum
+
+      - name: Install locked dependencies
+        shell: pwsh
+        run: |
+          uv python install 3.11
+          uv sync --locked --python 3.11 --extra all --extra dev
+          npm ci --no-audit --no-fund
+
+      - id: channel
+        name: Resolve release channel and tag contract
+        shell: pwsh
+        run: |
+          $distribution = Get-Content -LiteralPath downstream/distribution.json -Raw | ConvertFrom-Json
+          $channel = if ($env:GITHUB_REF_TYPE -eq 'tag') {
+            $expectedTag = "v$($distribution.version)"
+            if ($env:GITHUB_REF_NAME -ne $expectedTag) {
+              throw "Release tag $env:GITHUB_REF_NAME does not match $expectedTag"
+            }
+            'stable'
+          } elseif ('${{ github.event_name }}' -eq 'workflow_dispatch') {
+            '${{ inputs.channel }}'
+          } else {
+            'preview'
+          }
+          "channel=$channel" >> $env:GITHUB_OUTPUT
+
+      - name: Build current installer and portable archive
+        shell: pwsh
+        run: |
+          npm --workspace apps/desktop run build
+          npm --workspace apps/desktop run builder -- --win nsis zip
+
+      - id: current
+        name: Resolve current artifacts
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem -LiteralPath apps/desktop/release -Filter '*.exe' -File |
+            Where-Object { $_.Name -notlike '*uninstaller*' } | Select-Object -First 1
+          $portable = Get-ChildItem -LiteralPath apps/desktop/release -Filter '*.zip' -File |
+            Select-Object -First 1
+          if (-not $installer -or -not $portable) { throw 'Installer and portable artifacts are required' }
+          "installer=$($installer.FullName)" >> $env:GITHUB_OUTPUT
+          "portable=$($portable.FullName)" >> $env:GITHUB_OUTPUT
+
+      - id: baseline
+        name: Resolve upgrade baseline
+        shell: pwsh
+        run: |
+          if ('${{ github.event_name }}' -eq 'workflow_dispatch' -and '${{ inputs.baseline-ref }}') {
+            $baseline = '${{ inputs.baseline-ref }}'
+          } elseif ($env:GITHUB_REF_TYPE -eq 'tag') {
+            $baseline = git tag --merged HEAD --list 'v*.*.*-win.*' --sort=-v:refname |
+              Where-Object { $_ -ne $env:GITHUB_REF_NAME } | Select-Object -First 1
+            if (-not $baseline) { $baseline = $env:BASELINE_FALLBACK_SHA }
+          } else {
+            $baseline = '${{ github.event.before }}'
+            if (-not $baseline -or $baseline -match '^0+$') { $baseline = $env:BASELINE_FALLBACK_SHA }
+          }
+          git cat-file -e "$baseline^{commit}"
+          if ($LASTEXITCODE -ne 0) { throw "Upgrade baseline is not available: $baseline" }
+          $sha = (git rev-parse "$baseline^{commit}").Trim()
+          "ref=$baseline" >> $env:GITHUB_OUTPUT
+          "sha=$sha" >> $env:GITHUB_OUTPUT
+
+      - id: previous
+        name: Build upgrade baseline installer
+        shell: pwsh
+        run: |
+          $baselineRoot = Join-Path $env:RUNNER_TEMP 'hermes-upgrade-baseline'
+          $baselineOutput = Join-Path $env:RUNNER_TEMP 'hermes-upgrade-baseline-output'
+          git worktree add --detach $baselineRoot '${{ steps.baseline.outputs.sha }}'
+          Push-Location $baselineRoot
+          try {
+            npm ci --no-audit --no-fund
+            npm --workspace apps/desktop run build
+            npm --workspace apps/desktop run builder -- --win nsis --config.directories.output=$baselineOutput
+          } finally {
+            Pop-Location
+          }
+          $installer = Get-ChildItem -LiteralPath $baselineOutput -Filter '*.exe' -File |
+            Where-Object { $_.Name -notlike '*uninstaller*' } | Select-Object -First 1
+          if (-not $installer) { throw 'Upgrade baseline installer was not built' }
+          "installer=$($installer.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Run Windows qualification
+        shell: pwsh
+        run: |
+          & scripts/windows/Test-HermesWindowsQualification.ps1 `
+            -OutputDirectory (Join-Path $env:RUNNER_TEMP 'windows-qualification') `
+            -InstallerPath '${{ steps.current.outputs.installer }}' `
+            -PortablePath '${{ steps.current.outputs.portable }}' `
+            -PreviousInstallerPath '${{ steps.previous.outputs.installer }}' `
+            -Scope ci
+
+      - id: signing
+        name: Record Authenticode status
+        shell: pwsh
+        run: |
+          $signature = Get-AuthenticodeSignature -LiteralPath '${{ steps.current.outputs.installer }}'
+          $signed = ($signature.Status -eq 'Valid').ToString().ToLowerInvariant()
+          "signed=$signed" >> $env:GITHUB_OUTPUT
+          "status=$($signature.Status)" >> $env:GITHUB_OUTPUT
+          Write-Host "Installer Authenticode status: $($signature.Status)"
+
+      - name: Attest executable and portable provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+        with:
+          subject-path: |
+            ${{ steps.current.outputs.installer }}
+            ${{ steps.current.outputs.portable }}
+
+      - name: Generate canonical release bundle
+        shell: pwsh
+        run: |
+          $bundle = Join-Path $env:RUNNER_TEMP 'windows-release-bundle'
+          uv run --no-sync python scripts/downstream/generate_release_manifest.py `
+            --installer '${{ steps.current.outputs.installer }}' `
+            --portable '${{ steps.current.outputs.portable }}' `
+            --qualification (Join-Path $env:RUNNER_TEMP 'windows-qualification/windows-qualification.json') `
+            --output-dir $bundle `
+            --channel '${{ steps.channel.outputs.channel }}' `
+            --downstream-sha '${{ github.sha }}' `
+            --installer-signed '${{ steps.signing.outputs.signed }}' `
+            --attestation-status generated
+          Copy-Item -LiteralPath (Join-Path $env:RUNNER_TEMP 'windows-qualification') `
+            -Destination (Join-Path $bundle 'qualification') -Recurse
+          [ordered]@{
+            schema_version = 1
+            baseline_ref = '${{ steps.baseline.outputs.ref }}'
+            baseline_sha = '${{ steps.baseline.outputs.sha }}'
+            released_downstream_sha = '${{ github.sha }}'
+          } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $bundle 'upgrade-baseline.json') -Encoding utf8
+
+      - name: Upload qualified release bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: windows-release-${{ github.sha }}
+          path: ${{ runner.temp }}/windows-release-bundle
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Publish tag release
+        if: github.ref_type == 'tag'
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $bundle = Join-Path $env:RUNNER_TEMP 'windows-release-bundle'
+          $assets = @(
+            Get-ChildItem -LiteralPath $bundle -File -Recurse |
+              Select-Object -ExpandProperty FullName
+          )
+          gh release create $env:GITHUB_REF_NAME @assets `
+            --verify-tag `
+            --title "Hermes Agent Windows Workstation Edition $env:GITHUB_REF_NAME" `
+            --notes-file (Join-Path $bundle 'RELEASE_NOTES.md')

--- a/README.ja.md
+++ b/README.ja.md
@@ -17,6 +17,25 @@ Nous Research との提携関係はなく、同社による承認も受けてい
 
 [![Windows Workstation Tier-1 CI](https://github.com/zapabob/hermes-agent-windows/actions/workflows/fork-cicd.yml/badge.svg)](https://github.com/zapabob/hermes-agent-windows/actions/workflows/fork-cicd.yml)
 
+Windows 11 AI ワークステーション向けに、Windows ネイティブで継続的に認定する
+Hermes のダウンストリーム・ディストリビューションです。
+
+- Python、Electron、Go、upstream API 互換、regression、security lock の Windows Tier-1 CI
+- 非管理者・空白入り path を含む installer、portable、旧版からの upgrade E2E
+- 移動しない upstream snapshot `1fe0f2f3ac9748ce799272eb93bee2937b5ab802`
+- 公式 provider/memory seam 上の local llama.cpp/GGUF と embedding lifecycle
+- Desktop/backend と任意 embedding を限定的に復旧する外部 Go watchdog
+- GPU のない hosted CI と分離した consumer NVIDIA workstation の実機証拠
+
+release candidate は `0.20.5-win.1`、対応 channel は `stable` と `preview` です。
+認定済み成果物は対応 tag からのみ
+[ダウンストリーム Releases](https://github.com/zapabob/hermes-agent-windows/releases)
+へ公開します。最初の stable asset が存在するまでは source route を使用し、先行した
+direct download button は表示しません。
+[Windows 導入ガイド](docs/windows/INSTALL.md)、
+[release policy](docs/windows/RELEASE_POLICY.md)、
+[公式 upstream](https://github.com/NousResearch/hermes-agent)も参照してください。
+
 ## 1. 製品の位置づけ
 
 Hermes Agent Windows Workstation Edition は、常時稼働するローカル AI
@@ -134,14 +153,21 @@ generation は、外部 account への公開や変更を許可するものでは
 
 ## 11. インストール
 
-現在、このリポジトリでは fork 固有の検証済み binary installer を案内していません。
-PowerShell で source からインストールしてください。
+Windows release workflow は、ユーザー単位の NSIS installer と portable ZIP を作成し、
+stable tag で公開する前に clean install、起動、upgrade E2E を実行します。公開済みの
+成果物は
+[ダウンストリーム Releases](https://github.com/zapabob/hermes-agent-windows/releases)
+からのみ取得し、`SHA256SUMS.txt` を確認してください。現在の candidate は
+`release-manifest.json` に別の記録がない限り unsigned です。手順の正本は
+[docs/windows/INSTALL.md](docs/windows/INSTALL.md) です。
+
+source/development route は PowerShell から引き続き利用できます。
 
 ```powershell
 git clone https://github.com/zapabob/hermes-agent-windows.git
 Set-Location hermes-agent-windows
-uv sync --all-extras
-uv run hermes --help
+uv sync --locked --all-extras
+uv run hermes --version
 uv run hermes setup
 ```
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,25 @@ Original Hermes Agent is developed by Nous Research and licensed under MIT.
 
 [![Windows Workstation Tier-1 CI](https://github.com/zapabob/hermes-agent-windows/actions/workflows/fork-cicd.yml/badge.svg)](https://github.com/zapabob/hermes-agent-windows/actions/workflows/fork-cicd.yml)
 
+Windows-first, locally qualified Hermes distribution for Windows 11 AI
+workstations.
+
+- Native Windows Tier-1 CI for Python, Electron, Go, upstream API compatibility, regressions, and security locks.
+- Qualified installer, portable, and prior-version upgrade paths with spaces and non-admin operation.
+- Frozen upstream snapshot `1fe0f2f3ac9748ce799272eb93bee2937b5ab802`, never a moving release baseline.
+- Local llama.cpp/GGUF and embedding lifecycles through official provider and memory seams.
+- External Go watchdog for bounded Desktop/backend and optional embedding recovery.
+- Consumer NVIDIA workstation evidence kept separate from GPU-free hosted CI.
+
+Release candidate: `0.20.5-win.1`. Supported channels: `stable` and `preview`.
+Qualified artifacts are published only from the matching version tag on the
+[downstream Releases page](https://github.com/zapabob/hermes-agent-windows/releases).
+Until the first stable asset is present there, use the source route below; no
+direct download button is advertised early. See the
+[Windows installation guide](docs/windows/INSTALL.md),
+[release policy](docs/windows/RELEASE_POLICY.md), and
+[official upstream](https://github.com/NousResearch/hermes-agent).
+
 ## 1. Product identity
 
 Hermes Agent Windows Workstation Edition is a feature-rich Windows-first
@@ -138,14 +157,21 @@ does not imply authorization to publish or mutate an external account.
 
 ## 11. Installation
 
-There is currently no verified fork-specific binary installer advertised by
-this repository. Install from source in PowerShell:
+The Windows release workflow produces a per-user NSIS installer and a portable
+ZIP, then runs clean-install, launch, and upgrade E2E before a stable tag may
+publish them. Obtain published artifacts only from the
+[downstream Releases page](https://github.com/zapabob/hermes-agent-windows/releases)
+and verify `SHA256SUMS.txt`. The current candidate is reported as unsigned
+unless its `release-manifest.json` says otherwise. Full instructions are in
+[docs/windows/INSTALL.md](docs/windows/INSTALL.md).
+
+The source/development route remains available in PowerShell:
 
 ```powershell
 git clone https://github.com/zapabob/hermes-agent-windows.git
 Set-Location hermes-agent-windows
-uv sync --all-extras
-uv run hermes --help
+uv sync --locked --all-extras
+uv run hermes --version
 uv run hermes setup
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,23 @@ Hermes Agent 的 Windows 优先下游发行版。
 
 [![Windows Workstation Tier-1 CI](https://github.com/zapabob/hermes-agent-windows/actions/workflows/fork-cicd.yml/badge.svg)](https://github.com/zapabob/hermes-agent-windows/actions/workflows/fork-cicd.yml)
 
+面向 Windows 11 AI 工作站、在 Windows 原生环境持续验证的 Hermes 下游发行版。
+
+- Python、Electron、Go、upstream API 兼容、regression 与 security lock 的 Windows Tier-1 CI
+- 覆盖非管理员与含空格 path 的 installer、portable、旧版 upgrade E2E
+- 固定 upstream snapshot `1fe0f2f3ac9748ce799272eb93bee2937b5ab802`，不使用移动基线
+- 通过官方 provider/memory seam 连接 local llama.cpp/GGUF 与 embedding lifecycle
+- 由外部 Go watchdog 对 Desktop/backend 及可选 embedding 执行有限恢复
+- consumer NVIDIA workstation 实机证据与无 GPU 的 hosted CI 分开记录
+
+release candidate 为 `0.20.5-win.1`，支持 `stable` 与 `preview` channel。
+通过验证的产物只从对应 tag 发布到
+[下游 Releases](https://github.com/zapabob/hermes-agent-windows/releases)。
+在首个 stable asset 实际存在前，请使用 source route，不提前展示 direct download button。
+另见 [Windows 安装指南](docs/windows/INSTALL.md)、
+[release policy](docs/windows/RELEASE_POLICY.md) 与
+[官方 upstream](https://github.com/NousResearch/hermes-agent)。
+
 ## 1. 产品定位
 
 Hermes Agent Windows Workstation Edition 是面向持久运行的本地 AI 工作站、功能完整的
@@ -122,14 +139,20 @@ TTS contract，而不会把 core 改造成 VR 或 voice 专用 runtime。
 
 ## 11. 安装
 
-本仓库目前没有对外提供经过验证的 fork 专用 binary installer。请在 PowerShell 中从
-source 安装：
+Windows release workflow 会生成用户级 NSIS installer 与 portable ZIP，并在 stable
+tag 发布前执行 clean install、启动与 upgrade E2E。只从
+[下游 Releases](https://github.com/zapabob/hermes-agent-windows/releases)
+获取已发布产物，并核对 `SHA256SUMS.txt`。除非 `release-manifest.json` 另有记录，
+当前 candidate 按 unsigned 处理。完整步骤见
+[docs/windows/INSTALL.md](docs/windows/INSTALL.md)。
+
+source/development route 仍可在 PowerShell 中使用：
 
 ```powershell
 git clone https://github.com/zapabob/hermes-agent-windows.git
 Set-Location hermes-agent-windows
-uv sync --all-extras
-uv run hermes --help
+uv sync --locked --all-extras
+uv run hermes --version
 uv run hermes setup
 ```
 

--- a/_docs/2026-08-27_windows-distribution-release-v1_codex.md
+++ b/_docs/2026-08-27_windows-distribution-release-v1_codex.md
@@ -1,0 +1,128 @@
+# Windows Distribution Release v1
+
+Date: 2026-08-27
+
+## Frozen scope
+
+- Downstream start SHA: `8447bf369a0977b0dadf5c78896e194001dd1584`
+- Frozen upstream snapshot SHA: `1fe0f2f3ac9748ce799272eb93bee2937b5ab802`
+- Distribution version: `0.20.5-win.1`
+- Implementation branch: `codex/distribution-windows-release-v1-20260827`
+- Implementation worktree: isolated from the live primary checkout
+
+The recorded upstream snapshot remained unchanged. This work did not fetch or
+adopt a newer upstream `main` commit.
+
+## Distribution contract
+
+`downstream/distribution.json` is the product authority for the Windows
+Workstation Edition. It defines the downstream repository, frozen upstream
+snapshot, release version, supported architecture, platform tier, release
+channels, and downstream-only update branch.
+
+The CLI version surface, Windows bootstrap installers, Electron bootstrap, and
+Tauri bootstrap all consume that authority. The downstream updater recognizes
+the downstream origin as managed and fails closed when distribution metadata is
+unavailable. It does not silently fall back to the official upstream archive.
+
+## Packaging and release engineering
+
+The Desktop package produces an NSIS installer and portable ZIP with downstream
+product identity. The NSIS upgrade GUID preserves the previous application
+identity so an installed Hermes version can be upgraded in place. Embedded PE
+metadata records the display name, distribution identifier, and downstream
+version.
+
+The release bundle generator copies qualified artifacts into canonical names,
+computes SHA-256 hashes, writes `release-manifest.json` and `SHA256SUMS.txt`, and
+generates release notes from tracked manifests plus Git history. A stable bundle
+is rejected unless every required gate passed for the exact downstream SHA,
+`ci_qualified` is true, hashes and the upstream snapshot are present, and the
+provenance attestation was generated.
+
+The GitHub release workflow is SHA-pinned. A `main` push creates a non-publishing
+preview qualification artifact. Only the tag matching the version authority may
+publish a stable GitHub Release.
+
+## Windows qualification
+
+The qualification report includes these required release gates:
+
+- `install_e2e`
+- `portable_e2e`
+- `upgrade_e2e`
+- `windows_native_python`
+- `windows_native_desktop`
+- `watchdog_go`
+- `upstream_api_compat`
+- `windows_regression`
+- `security_locks`
+
+Installer E2E performs a silent non-administrator install into a path containing
+spaces, validates embedded identity, launches the packaged Desktop, and runs the
+uninstaller. Portable E2E extracts into a path containing spaces, validates the
+standalone resource layout and identity, and launches without a developer
+checkout. Upgrade E2E installs the baseline, writes profile data, upgrades in
+place, proves the profile sentinel remains, validates the new identity, and
+launches the upgraded Desktop.
+
+Recursive cleanup is limited to a freshly generated, directly nested operating
+system temporary directory whose name matches the qualification run type and
+GUID. Only processes whose executable path belongs to that run are stopped.
+
+## Local evidence before candidate publication
+
+- Focused Python release, update, startup, and provider contracts: 49 passed
+  after final environment-isolation hardening.
+- Broader focused Python qualification set: 112 passed.
+- Electron distribution/bootstrap tests: 13 passed.
+- PE identity test: 1 passed.
+- Desktop TypeScript typecheck: passed.
+- Desktop build: passed.
+- Go watchdog tests: passed.
+- Changed PowerShell scripts: parser passed.
+- Installer E2E: passed against the built `0.20.5-win.1` artifact.
+- Portable E2E: passed against the built `0.20.5-win.1` artifact.
+- Upgrade E2E: passed from the recorded downstream start build to the current
+  artifact with profile data preserved.
+- Integrated local qualification: all nine required gates passed. The report
+  correctly records `executed_in_ci: false` and `ci_qualified: false`; local
+  execution is not promoted into cloud CI evidence.
+
+The locally built installer reported Authenticode status `NotSigned`. The
+manifest and documentation preserve that fact. No self-signed or fabricated
+publisher identity is used.
+
+## Real workstation evidence boundary
+
+The privacy-safe collector records Windows and GPU facts, exact SHAs, artifact
+identity and hash, matching Desktop distribution identity, loopback health, and
+explicit sleep/resume and physical restart results. It does not record usernames,
+executable paths, model paths, command lines, secrets, prompts, or sessions.
+
+The partial local report observed Windows 11 Pro and an NVIDIA RTX 5060 Ti with
+16,311 MiB reported VRAM. Backend and watchdog health passed, but no running
+Desktop process matched the candidate distribution identity. Llama and embedding
+health did not pass, while sleep/resume and physical restart were not run.
+Accordingly, real-workstation qualification remains failed and must not be
+inferred from native Windows CI.
+
+## Rollback and recovery
+
+The release changes are isolated on the implementation branch until exact-head
+checks pass. The downstream updater retains the existing transactional plan,
+snapshot, apply, restart, verify, and receipt stages. Installer E2E uses isolated
+temporary roots, and upgrade E2E preserves profile data independently from the
+installation directory.
+
+A published release can be rolled back by reinstalling the previous qualified
+installer or portable artifact using its recorded hash. Upstream adoption remains
+a separate, explicit compatibility decision against the frozen snapshot.
+
+## Publication evidence authority
+
+Candidate, `main`, and stable-release verdicts are exact-SHA claims. Their final
+evidence is the GitHub checks and release object for that SHA, plus the release
+manifest, qualification report, hashes, and provenance attestation. A passing
+parent commit, unrelated pull request, or local-only run is not publication
+evidence.

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 430618,
-    "carry_surface_files": 949,
-    "cwc": 155355,
-    "fork_owned_loc": 312233,
-    "upstream_owned_fork_loc": 118385,
-    "utr": 0.274919
+    "all_fork_specific_loc": 434169,
+    "carry_surface_files": 959,
+    "cwc": 156111,
+    "fork_owned_loc": 315431,
+    "upstream_owned_fork_loc": 118738,
+    "utr": 0.273483
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,12 +4,12 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 430618 |
-| Upstream-owned fork LOC | 118385 |
-| Fork-owned LOC | 312233 |
-| UTR | 0.274919 |
-| Carry Surface | 949 files |
-| CWC | 155355 |
+| All fork-specific LOC | 434169 |
+| Upstream-owned fork LOC | 118738 |
+| Fork-owned LOC | 315431 |
+| UTR | 0.273483 |
+| Carry Surface | 959 files |
+| CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.
 Generated metric reports are excluded to avoid self-referential totals.

--- a/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
+++ b/apps/bootstrap-installer/src-tauri/src/bootstrap.rs
@@ -933,6 +933,14 @@ fn build_pin_args(script: &install_script::ResolvedScript) -> Vec<String> {
         out.push("-Branch".to_string());
         out.push(b.clone());
     }
+    if cfg!(target_os = "windows") {
+        out.push("-RepositoryUrlHttps".to_string());
+        out.push(script.repository.https.clone());
+        out.push("-RepositoryUrlSsh".to_string());
+        out.push(script.repository.ssh.clone());
+        out.push("-RepositoryArchiveBase".to_string());
+        out.push(script.repository.archive_base.clone());
+    }
     out
 }
 

--- a/apps/bootstrap-installer/src-tauri/src/install_script.rs
+++ b/apps/bootstrap-installer/src-tauri/src/install_script.rs
@@ -19,6 +19,27 @@ use tokio::io::AsyncWriteExt;
 
 use crate::paths;
 
+const DISTRIBUTION_JSON: &str = include_str!("../../../../downstream/distribution.json");
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct RepositoryAuthority {
+    pub https: String,
+    pub ssh: String,
+    pub raw_base: String,
+    pub archive_base: String,
+}
+
+#[derive(serde::Deserialize)]
+struct DistributionAuthority {
+    repository: RepositoryAuthority,
+}
+
+fn repository_authority() -> Result<RepositoryAuthority> {
+    let distribution: DistributionAuthority =
+        serde_json::from_str(DISTRIBUTION_JSON).context("parsing distribution.json")?;
+    Ok(distribution.repository)
+}
+
 /// Identity of the install.ps1 we'll execute. Used by both the manifest
 /// fetch and the per-stage runs.
 #[derive(Debug, Clone)]
@@ -29,6 +50,7 @@ pub struct ResolvedScript {
     /// what makes the repo stage clone the exact tested SHA.
     pub commit: Option<String>,
     pub branch: Option<String>,
+    pub repository: RepositoryAuthority,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -102,6 +124,7 @@ pub async fn resolve(
     pin: &Pin,
     emit_log: &impl Fn(&str),
 ) -> Result<ResolvedScript> {
+    let repository = repository_authority()?;
     // 1. Dev shortcut.
     if let Ok(repo_root) = std::env::var("HERMES_SETUP_DEV_REPO_ROOT") {
         let candidate = PathBuf::from(repo_root).join("scripts").join(kind.filename());
@@ -116,6 +139,7 @@ pub async fn resolve(
                 source: ScriptSource::DevCheckout,
                 commit: pin.commit.clone(),
                 branch: pin.branch.clone(),
+                repository,
             });
         }
     }
@@ -159,6 +183,7 @@ pub async fn resolve(
                 source: ScriptSource::Cached,
                 commit: pin.commit.clone(),
                 branch: pin.branch.clone(),
+                repository,
             });
         }
         CachePlan::Fetch { stale_ok } => {
@@ -173,7 +198,7 @@ pub async fn resolve(
                 truncate_ref(&commit_or_ref)
             ));
 
-            match download(kind, &commit_or_ref, &cached).await {
+            match download(kind, &commit_or_ref, &cached, &repository).await {
                 Ok(()) => {
                     emit_log(&format!("[bootstrap] cached to {}", cached.display()));
                     Ok(ResolvedScript {
@@ -181,6 +206,7 @@ pub async fn resolve(
                         source: ScriptSource::Downloaded,
                         commit: pin.commit.clone(),
                         branch: pin.branch.clone(),
+                        repository: repository.clone(),
                     })
                 }
                 Err(err) if stale_ok => {
@@ -197,6 +223,7 @@ pub async fn resolve(
                         source: ScriptSource::Cached,
                         commit: pin.commit.clone(),
                         branch: pin.branch.clone(),
+                        repository,
                     })
                 }
                 Err(err) => Err(err),
@@ -322,9 +349,15 @@ fn upgrade_cached_script(kind: ScriptKind, cached: &Path, emit_log: &impl Fn(&st
 /// black-holed connection (captive portal, hung proxy, silently dropped
 /// packets) never errors — the whole bootstrap would hang here instead of
 /// falling back to the cached script.
-async fn download(kind: ScriptKind, commit_or_ref: &str, dest_path: &Path) -> Result<()> {
+async fn download(
+    kind: ScriptKind,
+    commit_or_ref: &str,
+    dest_path: &Path,
+    repository: &RepositoryAuthority,
+) -> Result<()> {
     let url = format!(
-        "https://raw.githubusercontent.com/NousResearch/hermes-agent/{}/scripts/{}",
+        "{}/{}/scripts/{}",
+        repository.raw_base.trim_end_matches('/'),
         commit_or_ref,
         kind.filename()
     );
@@ -463,6 +496,20 @@ mod tests {
             cache_plan(/*immutable=*/ true, /*cached_exists=*/ false),
             CachePlan::Fetch { stale_ok: false }
         );
+    }
+
+    #[test]
+    fn repository_authority_targets_the_downstream_distribution() {
+        let repository = repository_authority().unwrap();
+        assert_eq!(
+            repository.https,
+            "https://github.com/zapabob/hermes-agent-windows.git"
+        );
+        assert_eq!(
+            repository.raw_base,
+            "https://raw.githubusercontent.com/zapabob/hermes-agent-windows"
+        );
+        assert!(!repository.raw_base.contains("NousResearch"));
     }
 
     #[test]

--- a/apps/desktop/electron/bootstrap-runner.test.ts
+++ b/apps/desktop/electron/bootstrap-runner.test.ts
@@ -21,6 +21,15 @@ import {
 const SCRIPT_NAME = process.platform === 'win32' ? 'install.ps1' : 'install.sh'
 const ZERO_COMMIT = '0000000000000000000000000000000000000000'
 
+const DOWNSTREAM_REPOSITORY_ARGS = [
+  '-RepositoryUrlHttps',
+  'https://github.com/zapabob/hermes-agent-windows.git',
+  '-RepositoryUrlSsh',
+  'git@github.com:zapabob/hermes-agent-windows.git',
+  '-RepositoryArchiveBase',
+  'https://github.com/zapabob/hermes-agent-windows/archive'
+]
+
 function mkTmpHome() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-bootstrap-test-'))
 }
@@ -84,7 +93,13 @@ test('existing checkout detection requires git metadata', () => {
 test('fresh bootstrap args include the packaged commit pin', () => {
   const installStamp = { commit: 'a'.repeat(40), branch: 'main' }
 
-  assert.deepEqual(buildPinArgs(installStamp), ['-Commit', installStamp.commit, '-Branch', 'main'])
+  assert.deepEqual(buildPinArgs(installStamp), [
+    ...DOWNSTREAM_REPOSITORY_ARGS,
+    '-Commit',
+    installStamp.commit,
+    '-Branch',
+    'main'
+  ])
   assert.deepEqual(
     buildPosixPinArgs({
       installStamp,
@@ -98,7 +113,11 @@ test('fresh bootstrap args include the packaged commit pin', () => {
 test('existing-checkout bootstrap args keep branch but skip the packaged commit pin', () => {
   const installStamp = { commit: 'a'.repeat(40), branch: 'main' }
 
-  assert.deepEqual(buildPinArgs(installStamp, { pinCommit: false }), ['-Branch', 'main'])
+  assert.deepEqual(buildPinArgs(installStamp, { pinCommit: false }), [
+    ...DOWNSTREAM_REPOSITORY_ARGS,
+    '-Branch',
+    'main'
+  ])
   assert.deepEqual(
     buildPosixPinArgs({
       installStamp,
@@ -120,7 +139,7 @@ test('fallback install stamps use an unpinned branch ref', () => {
     pinned: false
   })
   // Must NOT pass -Commit / --commit for the all-zero placeholder.
-  assert.deepEqual(buildPinArgs(stamp), ['-Branch', 'main'])
+  assert.deepEqual(buildPinArgs(stamp), [...DOWNSTREAM_REPOSITORY_ARGS, '-Branch', 'main'])
   assert.deepEqual(
     buildPosixPinArgs({
       installStamp: stamp,

--- a/apps/desktop/electron/bootstrap-runner.ts
+++ b/apps/desktop/electron/bootstrap-runner.ts
@@ -38,6 +38,7 @@ import fsp from 'node:fs/promises'
 import https from 'node:https'
 import path from 'node:path'
 
+import { distributionInstallArgs, distributionRawUrl } from './distribution'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 const IS_WINDOWS = process.platform === 'win32'
@@ -233,7 +234,7 @@ function downloadInstallScript(ref, destPath) {
   // ref so local builds can still bootstrap without pretending the all-zero
   // placeholder is a real GitHub commit.
   const scriptName = installScriptName()
-  const url = `https://raw.githubusercontent.com/NousResearch/hermes-agent/${ref}/scripts/${scriptName}`
+  const url = distributionRawUrl(ref, scriptName)
 
   return new Promise((resolve, reject) => {
     fs.mkdirSync(path.dirname(destPath), { recursive: true })
@@ -663,7 +664,7 @@ function spawnBash(scriptPath, args, { emit, stageName, abortSignal, hermesHome 
 // back to the commit baked into that app. All-zero fallback stamps are never
 // passed as -Commit/--commit — only the branch is used (#50823 / #50864 review).
 function buildPinArgs(installStamp, { pinCommit = true } = {}) {
-  const args = []
+  const args = distributionInstallArgs()
 
   if (pinCommit && installStamp && isPinnedCommit(installStamp.commit)) {
     args.push('-Commit', installStamp.commit)

--- a/apps/desktop/electron/distribution.test.ts
+++ b/apps/desktop/electron/distribution.test.ts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+import { distributionInstallArgs, distributionRawUrl, loadDistributionMetadata } from './distribution'
+
+
+test('distribution metadata controls Desktop repository authority', () => {
+  const metadataPath = path.resolve(process.cwd(), '../../downstream/distribution.json')
+  const distribution = loadDistributionMetadata(metadataPath)
+
+  assert.equal(distribution.id, 'hermes-agent-windows')
+  assert.equal(distribution.repository.slug, 'zapabob/hermes-agent-windows')
+  assert.equal(distribution.update.allow_upstream_sync, false)
+})
+
+test('Desktop bootstrap URLs and install args target the downstream repository', () => {
+  const url = distributionRawUrl('a'.repeat(40), 'install.ps1')
+  const args = distributionInstallArgs()
+
+  assert.equal(
+    url,
+    `https://raw.githubusercontent.com/zapabob/hermes-agent-windows/${'a'.repeat(40)}/scripts/install.ps1`
+  )
+  assert.deepEqual(args, [
+    '-RepositoryUrlHttps',
+    'https://github.com/zapabob/hermes-agent-windows.git',
+    '-RepositoryUrlSsh',
+    'git@github.com:zapabob/hermes-agent-windows.git',
+    '-RepositoryArchiveBase',
+    'https://github.com/zapabob/hermes-agent-windows/archive'
+  ])
+  assert.equal(url.includes('NousResearch'), false)
+  assert.equal(
+    distributionRawUrl('preview/windows', 'install.ps1'),
+    'https://raw.githubusercontent.com/zapabob/hermes-agent-windows/preview/windows/scripts/install.ps1'
+  )
+})

--- a/apps/desktop/electron/distribution.ts
+++ b/apps/desktop/electron/distribution.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+interface DistributionRepository {
+  slug: string
+  web: string
+  https: string
+  ssh: string
+  raw_base: string
+  archive_base: string
+}
+
+interface DistributionUpdate {
+  branch: string
+  allow_upstream_sync: boolean
+}
+
+interface DistributionMetadata {
+  id: string
+  display_name: string
+  version: string
+  repository: DistributionRepository
+  update: DistributionUpdate
+}
+
+function distributionCandidates(): string[] {
+  return [
+    path.join(process.resourcesPath || '', 'distribution', 'distribution.json'),
+    path.resolve(__dirname, '../../..', 'downstream', 'distribution.json'),
+    path.resolve(process.cwd(), '../../downstream/distribution.json')
+  ]
+}
+
+function loadDistributionMetadata(metadataPath?: string): DistributionMetadata {
+  const candidate = metadataPath || distributionCandidates().find(item => fs.existsSync(item))
+
+  if (!candidate) {
+    throw new Error('downstream/distribution.json is required for Desktop bootstrap')
+  }
+
+  return JSON.parse(fs.readFileSync(candidate, 'utf8')) as DistributionMetadata
+}
+
+function distributionRawUrl(ref: string, scriptName: string): string {
+  const repository = loadDistributionMetadata().repository
+  const encodedRef = ref.split('/').map(encodeURIComponent).join('/')
+
+  return `${repository.raw_base}/${encodedRef}/scripts/${encodeURIComponent(scriptName)}`
+}
+
+function distributionInstallArgs(): string[] {
+  const repository = loadDistributionMetadata().repository
+
+  return [
+    '-RepositoryUrlHttps',
+    repository.https,
+    '-RepositoryUrlSsh',
+    repository.ssh,
+    '-RepositoryArchiveBase',
+    repository.archive_base
+  ]
+}
+
+export { distributionInstallArgs, distributionRawUrl, loadDistributionMetadata }
+export type { DistributionMetadata }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,10 +1,10 @@
 {
   "name": "hermes",
-  "productName": "Hermes",
+  "productName": "Hermes Agent Windows Workstation Edition",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.20.5-win.1",
   "description": "Native desktop shell for Hermes Agent.",
-  "author": "Nous Research",
+  "author": "zapabob and Nous Research contributors",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/zapabob/hermes-agent-windows.git"
@@ -40,6 +40,7 @@
     "dist:win": "npm run build && npm run builder -- --win",
     "dist:win:msi": "npm run build && npm run builder -- --win msi",
     "dist:win:nsis": "npm run build && npm run builder -- --win nsis",
+    "dist:win:portable": "npm run build && npm run builder -- --win zip",
     "dist:linux": "npm run build && npm run builder -- --linux AppImage deb rpm",
     "perf": "node scripts/perf/run.mjs",
     "update:shim": "bash ../../scripts/desktop-update/repro.sh shim",
@@ -188,8 +189,8 @@
   },
   "build": {
     "electronVersion": "41.10.3",
-    "appId": "com.nousresearch.hermes",
-    "productName": "Hermes",
+    "appId": "io.github.zapabob.hermes-agent-windows",
+    "productName": "Hermes Agent Windows Workstation Edition",
     "executableName": "Hermes",
     "protocols": [
       {
@@ -221,6 +222,10 @@
       {
         "from": "assets/icon.ico",
         "to": "icon.ico"
+      },
+      {
+        "from": "../../downstream/distribution.json",
+        "to": "distribution/distribution.json"
       }
     ],
     "asar": true,
@@ -279,10 +284,11 @@
       ]
     },
     "win": {
-      "legalTrademarks": "Hermes",
+      "legalTrademarks": "Hermes Agent Windows Workstation Edition",
       "target": [
         "nsis",
-        "msi"
+        "msi",
+        "zip"
       ],
       "signAndEditExecutable": false
     },
@@ -297,6 +303,7 @@
       ]
     },
     "nsis": {
+      "guid": "48ae4bdc-0f8d-5252-af1e-bf7c0a8c3649",
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
       "perMachine": false,

--- a/apps/desktop/scripts/set-exe-identity.mjs
+++ b/apps/desktop/scripts/set-exe-identity.mjs
@@ -36,7 +36,7 @@
 // otherwise-good build (worst case: stock icon, not a broken app).
 
 import { resolve, join } from 'node:path'
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 
 import { rcedit } from 'rcedit'
 
@@ -45,6 +45,19 @@ import { isMain } from './utils.mjs'
 // Stamp the Hermes icon + identity onto `exe`. Resolves on success, throws on
 // failure. `desktopRoot` defaults to this script's package root so the icon and
 // the rcedit dependency resolve regardless of cwd.
+function loadDistributionIdentity(desktopRoot) {
+  const metadataPath = resolve(desktopRoot, '../..', 'downstream', 'distribution.json')
+  const distribution = JSON.parse(readFileSync(metadataPath, 'utf8'))
+  const match = /^(\d+)\.(\d+)\.(\d+)-win\.(\d+)$/.exec(distribution.version)
+  if (!match) {
+    throw new Error(`unsupported distribution version: ${distribution.version}`)
+  }
+  return {
+    ...distribution,
+    windowsVersion: match.slice(1).join('.')
+  }
+}
+
 async function stampExeIdentity(exe, desktopRoot = resolve(import.meta.dirname, '..')) {
   if (!exe || !existsSync(exe)) {
     throw new Error(`target exe not found: ${exe}`)
@@ -55,24 +68,30 @@ async function stampExeIdentity(exe, desktopRoot = resolve(import.meta.dirname, 
   if (!existsSync(icon)) {
     throw new Error(`icon not found: ${icon}`)
   }
+  const distribution = loadDistributionIdentity(desktopRoot)
 
   console.log(`[set-exe-identity] stamping ${exe}`)
   console.log(`[set-exe-identity] icon: ${icon}`)
 
   await rcedit(exe, {
     icon,
+    'file-version': distribution.windowsVersion,
+    'product-version': distribution.windowsVersion,
     'version-string': {
-      ProductName: 'Hermes',
-      FileDescription: 'Hermes',
-      CompanyName: 'Nous Research',
-      LegalCopyright: 'Copyright (c) 2026 Nous Research'
+      ProductName: distribution.display_name,
+      FileDescription: distribution.display_name,
+      CompanyName: 'zapabob and Hermes Agent contributors',
+      LegalCopyright: 'Copyright (c) 2026 zapabob and Hermes Agent contributors',
+      InternalName: distribution.id,
+      OriginalFilename: 'Hermes.exe',
+      SpecialBuild: distribution.version
     }
   })
 
   console.log('[set-exe-identity] done — Hermes icon + identity stamped')
 }
 
-export { stampExeIdentity }
+export { loadDistributionIdentity, stampExeIdentity }
 
 // CLI entry point: `node scripts/set-exe-identity.mjs <exe>`.
 if (isMain(import.meta.url)) {

--- a/apps/desktop/scripts/set-exe-identity.test.mjs
+++ b/apps/desktop/scripts/set-exe-identity.test.mjs
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { resolve } from 'node:path'
+
+import { loadDistributionIdentity } from './set-exe-identity.mjs'
+
+test('Windows executable identity comes from downstream distribution metadata', () => {
+  const distribution = loadDistributionIdentity(resolve(import.meta.dirname, '..'))
+
+  assert.equal(distribution.id, 'hermes-agent-windows')
+  assert.equal(distribution.display_name, 'Hermes Agent Windows Workstation Edition')
+  assert.equal(distribution.version, '0.20.5-win.1')
+  assert.equal(distribution.windowsVersion, '0.20.5.1')
+})

--- a/apps/desktop/scripts/set-exe-identity.test.mjs
+++ b/apps/desktop/scripts/set-exe-identity.test.mjs
@@ -1,14 +1,15 @@
-import assert from 'node:assert/strict'
-import test from 'node:test'
 import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
 
 import { loadDistributionIdentity } from './set-exe-identity.mjs'
 
-test('Windows executable identity comes from downstream distribution metadata', () => {
-  const distribution = loadDistributionIdentity(resolve(import.meta.dirname, '..'))
+describe('Windows executable identity', () => {
+  it('comes from downstream distribution metadata', () => {
+    const distribution = loadDistributionIdentity(resolve(import.meta.dirname, '..'))
 
-  assert.equal(distribution.id, 'hermes-agent-windows')
-  assert.equal(distribution.display_name, 'Hermes Agent Windows Workstation Edition')
-  assert.equal(distribution.version, '0.20.5-win.1')
-  assert.equal(distribution.windowsVersion, '0.20.5.1')
+    expect(distribution.id).toBe('hermes-agent-windows')
+    expect(distribution.display_name).toBe('Hermes Agent Windows Workstation Edition')
+    expect(distribution.version).toBe('0.20.5-win.1')
+    expect(distribution.windowsVersion).toBe('0.20.5.1')
+  })
 })

--- a/docs/windows/COMPARISON.md
+++ b/docs/windows/COMPARISON.md
@@ -1,0 +1,24 @@
+# Distribution comparison
+
+This document explains the downstream distribution without making unsupported
+negative claims about the official project.
+
+| Capability | Official Hermes | Windows Workstation Edition | Evidence |
+| --- | --- | --- | --- |
+| Hermes public APIs | Authoritative upstream contracts | Preserved and contract-tested | `tests/downstream/test_upstream_api_contracts.py` |
+| Native Windows CI | See upstream policy / not asserted here | Tier-1 jobs run on `windows-latest` | `.github/workflows/fork-cicd.yml` |
+| Release baseline | See upstream policy / not asserted here | Exact frozen and qualified upstream SHA | `.codex/UPSTREAM_SNAPSHOT.json` |
+| Windows path/process qualification | See upstream policy / not asserted here | Drive, MSYS/WSL alias, NTFS, process and IPC contracts | `tests/downstream/test_windows_contracts.py` |
+| External Go watchdog | See upstream policy / not asserted here | Separate Desktop/backend and embedding supervisor | `scripts/windows/watchdog-go/*_test.go` |
+| Local llama/GGUF lifecycle | Official provider contracts are authoritative | Windows launcher, fallback, hot-swap and health contracts | `tests/hermes_cli/test_llama_fallback_runtime.py` |
+| Local embedding supervision | Official memory/provider seams are authoritative | Optional loopback embedding recovery through the Go watchdog | `scripts/windows/watchdog-go/embedding_test.go` |
+| Consumer NVIDIA workstation target | See upstream policy / not asserted here | Windows 11 x64 and consumer NVIDIA evidence contract | `scripts/windows/Get-HermesWorkstationQualification.ps1` |
+| VRChat/Unity integrations | Official plugin registry is authoritative | Downstream plugins through official seams | `tests/plugins/test_vrchat_autonomy_plugin.py` |
+| Local voice stack | Official TTS contracts are authoritative | Irodori, VOICEVOX, and local TTS routes | `tests/plugins/test_irodori_tts_plugin.py` |
+| Semantic/cognitive memory | Official memory-provider interface is authoritative | Semantic Graph and Ebbinghaus extensions | `tests/plugins/test_semantic_graph_registration.py` |
+| Release manifest | See upstream policy / not asserted here | Deterministic identity, hashes, channels, qualification, signing | `scripts/downstream/generate_release_manifest.py` |
+| Windows install E2E | See upstream policy / not asserted here | Non-admin path-with-spaces installer, portable, and upgrade tests | `scripts/windows/Test-HermesInstallerE2E.ps1` |
+
+The downstream does not replace Nous Research Hermes. Operators who prefer the
+official release cadence and support model should use
+[NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent).

--- a/docs/windows/DEMO.md
+++ b/docs/windows/DEMO.md
@@ -1,0 +1,54 @@
+# Reproducible Windows demonstration
+
+`scripts/demo/windows-demo.ps1` uses a dedicated `HERMES_HOME`, installation
+directory, watchdog state directory, and non-production ports. It never reads
+or copies the operator's normal profile secrets, model paths, prompts, or
+sessions. Its default root is a fresh GUID-named temporary directory; an
+explicit `-DemoRoot` must not already exist.
+
+## Safe identity and installation run
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  scripts\demo\windows-demo.ps1 `
+  -InstallerPath .\Hermes-Agent-Windows-0.20.5-win.1-x64-Setup.exe `
+  -DemoRoot "$env:TEMP\HermesWindowsWorkstationDemo"
+```
+
+This verifies the dedicated clean installation, `hermes --version`, packaged
+Desktop launch, local llama endpoint, embedded distribution identity, clean
+build stamp, exact downstream commit, and frozen upstream identity. If the
+local endpoint is not running, the report remains failed.
+
+## Conversation and recovery run
+
+Start the local model first, close every non-demo `Hermes.exe`, then run:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  scripts\demo\windows-demo.ps1 `
+  -InstallerPath .\Hermes-Agent-Windows-0.20.5-win.1-x64-Setup.exe `
+  -ModelId local-model `
+  -RunConversation `
+  -ExerciseRecovery
+```
+
+Recovery mode refuses to proceed while another Hermes Desktop is running. It
+also refuses pre-existing listeners on its dedicated watchdog or backend port.
+It starts a dedicated Go watchdog, waits for its managed backend, terminates only
+the backend PID reported by that watchdog, observes a different healthy PID,
+and verifies that the demo session remains listed. It stops only the processes
+it started and leaves the demo directory for inspection.
+
+## 60 to 120 second recording shot list
+
+1. Show the downstream release page, tag, SHA-256 file, and unsigned/signed manifest field.
+2. Run the installer into the dedicated demo directory.
+3. Show `hermes --version` with downstream and frozen upstream identities.
+4. Launch the packaged Desktop and send the short local-model prompt.
+5. Show llama and watchdog health on loopback.
+6. Run recovery mode and show the reported backend PID change.
+7. Show the same demo session after recovery.
+8. End on `windows-demo.json` and the exact candidate SHA.
+
+The script does not upload recordings or post to social platforms.

--- a/docs/windows/INSTALL.md
+++ b/docs/windows/INSTALL.md
@@ -1,0 +1,81 @@
+# Install Hermes Agent Windows Workstation Edition
+
+This guide covers the unofficial downstream distribution in
+`zapabob/hermes-agent-windows`. It does not install or represent the official
+Nous Research distribution.
+
+## Supported target
+
+The qualified release target is Windows 11 x64 running native PowerShell,
+Python, Node, and Electron. WSL is not required and is not used as evidence for
+the Windows qualification gates. A consumer NVIDIA GPU is recommended for the
+local llama.cpp and embedding features, but the Desktop can use remote model
+providers without one.
+
+## Recommended installer
+
+Qualified builds are published on the
+[Windows downstream Releases page](https://github.com/zapabob/hermes-agent-windows/releases).
+Download the `Hermes-Agent-Windows-<version>-x64-Setup.exe`,
+`release-manifest.json`, and `SHA256SUMS.txt` files from the same release.
+Confirm the digest before running the installer:
+
+```powershell
+Get-FileHash .\Hermes-Agent-Windows-0.20.5-win.1-x64-Setup.exe -Algorithm SHA256
+Get-Content .\SHA256SUMS.txt
+```
+
+The current `0.20.5-win.1` candidate is intentionally represented as unsigned
+unless `release-manifest.json` records `installer_signed: true`. Windows
+SmartScreen or endpoint protection may therefore request confirmation. Check
+the exact SHA-256 value and GitHub provenance before proceeding. Do not disable
+antivirus globally.
+
+The NSIS installer is per-user, does not require elevation, and lets the user
+choose the destination. The usual default is under
+`%LOCALAPPDATA%\Programs`; the chosen directory is authoritative. Profile data
+remains separate under the active `HERMES_HOME`.
+
+## Portable archive
+
+Download `Hermes-Agent-Windows-<version>-x64-portable.zip`, verify its hash,
+and extract it into a user-writable directory. The archive supports paths with
+spaces and does not require a developer checkout. Start `Hermes.exe` from the
+extracted directory. Move the complete directory when relocating the portable
+installation.
+
+## First launch
+
+Start Hermes from the Start menu, the installer shortcut, or the extracted
+portable directory. Complete provider setup in the Desktop. Secrets belong in
+the profile-scoped secret store or `.env`; ordinary settings belong in
+`config.yaml`. Do not place API keys in the repository.
+
+Local llama.cpp/GGUF configuration is described in
+[local-secretary-runtime.md](../local-secretary-runtime.md). Watchdog-managed
+Desktop backend and embedding recovery are described in
+[watchdog-go/README.md](../../scripts/windows/watchdog-go/README.md).
+
+## Source and development install
+
+Git, PowerShell, and `uv` are required for a source checkout. Node.js is also
+required when building Desktop locally.
+
+```powershell
+git clone https://github.com/zapabob/hermes-agent-windows.git
+Set-Location hermes-agent-windows
+uv sync --locked --all-extras
+uv run hermes --version
+uv run hermes setup
+```
+
+For Desktop development:
+
+```powershell
+npm ci
+npm --workspace apps/desktop run typecheck
+npm --workspace apps/desktop run build
+```
+
+Source installation follows downstream `main`. Reproducible release installs
+use the exact release tag and commit recorded in `release-manifest.json`.

--- a/docs/windows/REAL_WORKSTATION_QUALIFICATION.md
+++ b/docs/windows/REAL_WORKSTATION_QUALIFICATION.md
@@ -1,0 +1,42 @@
+# Real workstation qualification
+
+GitHub-hosted Windows runners provide native CI evidence but no consumer GPU,
+sleep/resume observation, or physical reboot. Real-workstation qualification is
+therefore a separate report and must never be inferred from CI.
+
+## Safety and privacy
+
+The collector records Windows version/build, CPU architecture, NVIDIA model and
+VRAM, downstream and upstream SHAs, packaged executable identity and hash,
+aggregate Desktop process state and version identity, loopback health results,
+and explicit manual power-cycle results. A passing Desktop result requires a
+running executable whose embedded distribution identity matches the candidate.
+It does not record usernames, executable paths, local model paths, command
+lines, API keys, prompts, or private sessions.
+
+## Procedure
+
+Install the exact candidate, verify its hash, launch Desktop, and start the
+configured backend, watchdog, llama, and embedding services. Confirm each
+loopback endpoint locally. Then observe one sleep/resume cycle and one physical
+restart/recovery cycle. Do not claim either result before the machine returns
+and the relevant services are checked again.
+
+Run the collector from the exact candidate checkout:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File `
+  scripts\windows\Get-HermesWorkstationQualification.ps1 `
+  -ArtifactPath .\Hermes-Agent-Windows-0.20.5-win.1-x64-Setup.exe `
+  -SleepResumeResult passed `
+  -RestartRecoveryResult passed `
+  -OutputPath .\workstation-qualification.json
+```
+
+Use `-AllowIncomplete` only to inspect a partial local report; its overall
+status remains `failed`. Feed a passed report into
+`Test-HermesWindowsQualification.ps1 -Scope real_workstation` to produce the
+combined qualification evidence.
+
+The report is valid only for its recorded downstream commit and frozen upstream
+SHA. Hardware results must not be reused for a different candidate SHA.

--- a/docs/windows/RELEASE_POLICY.md
+++ b/docs/windows/RELEASE_POLICY.md
@@ -1,0 +1,45 @@
+# Windows release policy
+
+Official Hermes is the innovation stream. Hermes Agent Windows Workstation
+Edition is a qualified downstream baseline for native Windows workstations.
+The two projects retain separate release, issue, and support authorities.
+
+## Frozen release trains
+
+A release train starts from one exact upstream commit:
+
+```text
+upstream vX.Y.Z
+  -> Windows vX.Y.Z-win.1
+  -> Windows vX.Y.Z-win.2
+```
+
+The train may contain selected security backports, Windows-critical fixes, and
+downstream feature fixes. It never follows moving upstream `main`. Every
+manifest records the upstream SHA, downstream SHA, distribution version,
+channel, architecture, artifact hashes, signing state, and qualification state.
+
+## Stable and preview
+
+`preview` permits candidate artifacts and incomplete physical-workstation
+evidence. It must not be described as stable. A `stable` release requires all
+of these gates at the exact tagged commit: install E2E, portable E2E, upgrade
+E2E, native Windows Python, native Windows Desktop, Go watchdog, upstream API
+compatibility, Windows regressions, and security locks.
+
+Stable additionally requires recorded SHA-256 hashes, the frozen upstream SHA,
+an exact qualification-SHA match, `ci_qualified: true`, and generated GitHub
+artifact provenance. Real-workstation qualification is recorded independently
+and is never inferred from GitHub-hosted runners.
+
+## Publication
+
+Main-branch pushes build and qualify preview artifacts but do not publish a
+public GitHub Release. Only a version tag matching the distribution metadata,
+such as `v0.20.5-win.1`, may publish the stable bundle. The release contains the
+NSIS installer, portable ZIP, `release-manifest.json`, `SHA256SUMS.txt`, release
+notes, qualification reports, and upgrade-baseline identity.
+
+Authenticode signing is represented as observed. An unsigned installer remains
+unsigned in the manifest and documentation; no self-signed certificate is
+presented as trusted publisher identity.

--- a/docs/windows/TROUBLESHOOTING.md
+++ b/docs/windows/TROUBLESHOOTING.md
@@ -1,0 +1,72 @@
+# Windows troubleshooting
+
+Use the exact downstream version, commit, and frozen upstream SHA from
+`hermes --version` and `release-manifest.json` when reporting a problem. Never
+include API keys, model paths, usernames, prompts, or private session content.
+
+## Locked executable during update
+
+Close Hermes and allow the Desktop/backend processes to exit. If the Go
+watchdog is active, stop it through the operator-controlled process or its
+authenticated stop API before retrying. Do not widen process termination to
+unrelated Python, Node, or Electron processes.
+
+## Antivirus or SmartScreen warning
+
+The `0.20.5-win.1` candidate is unsigned unless its manifest says otherwise.
+Verify the SHA-256 hash and GitHub provenance, then submit a false-positive
+sample to the security vendor when appropriate. Do not disable real-time
+protection globally and do not add a broad drive exclusion.
+
+## Hermes is already running
+
+Use Task Manager to confirm whether the existing `Hermes.exe` belongs to the
+intended installation. Close that instance before opening a second portable or
+installed copy. The E2E scripts terminate only the process tree they started.
+
+## Port collision
+
+Common workstation endpoints include Desktop backend `9119`, watchdog `9920`,
+llama `8080`, and embeddings `8082`. Inspect listener ownership before changing
+configuration:
+
+```powershell
+Get-NetTCPConnection -State Listen | Where-Object LocalPort -In 8080,8082,9119,9920
+```
+
+Preserve unknown listeners. Change the Hermes setting or stop the confirmed
+owner rather than terminating a process based only on a port number.
+
+## Local llama is unavailable
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8080/v1/models -TimeoutSec 5
+powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\check-local-llm.ps1
+```
+
+Confirm the configured model exists without publishing its local path. Review
+`docs/local-secretary-runtime.md` for provider and port settings.
+
+## Watchdog status
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:9920/health -TimeoutSec 5
+Invoke-RestMethod http://127.0.0.1:9920/api/status -TimeoutSec 5
+```
+
+The watchdog is an external operator process. It is not a Hermes plugin, tool,
+skill, MCP server, or agent-reachable restart authority.
+
+## Desktop and backend version skew
+
+Check `hermes --version`, the packaged executable version fields, and the
+running gateway or backend status separately. Restarting Desktop does not prove
+that a detached gateway changed versions. Reinstall the exact downstream build
+and restart each applicable supervisor through its documented route.
+
+## Bounded recovery
+
+Use `scripts/windows/restart-hermes-stack.ps1` only after reviewing its target
+paths and options. For release evidence, run the dedicated demo or qualification
+script rather than modifying the primary profile. A physical reboot remains
+unverified until observed after the machine returns.

--- a/docs/windows/UPGRADE.md
+++ b/docs/windows/UPGRADE.md
@@ -1,0 +1,46 @@
+# Upgrade and rollback
+
+Hermes Agent Windows Workstation Edition updates only from
+`zapabob/hermes-agent-windows`. Official upstream is an integration input; it
+is not an update authority for an installed downstream workstation.
+
+## Channels
+
+`stable` accepts only an exact commit that passed every required Windows gate,
+has recorded artifact hashes and the frozen upstream SHA, and has generated
+provenance. `preview` is for candidate validation and may be incomplete. Change
+channels deliberately and read the manifest before installing a preview.
+
+## Upgrade
+
+Download the newer installer and its `SHA256SUMS.txt` from the same downstream
+release, verify the hash, close Hermes, and run the installer. The NSIS product
+GUID remains continuous with the prior Desktop identity so an existing
+installation is upgraded rather than forked into a second product.
+
+Profile data, configuration, memory, and sessions live outside the application
+directory and are preserved by the upgrade path. The qualification workflow
+also installs a prior build, writes a profile sentinel, upgrades it, launches
+the result, and verifies that the sentinel survived.
+
+Portable users should stop Hermes, retain the previous extracted directory,
+extract the new archive into a new directory, and launch it against the same
+profile. Do not overlay a running portable directory.
+
+## Frozen upstream baseline
+
+Every Windows release records one exact Nous Research commit. A later upstream
+commit does not enter an installed release until a new downstream train is
+qualified. The CLI version output and release manifest show both downstream
+and upstream identities.
+
+## Rollback
+
+Keep the previous verified installer or portable directory and its hash file.
+Stop Hermes and the Go watchdog, uninstall only the application when necessary,
+then install the previous downstream version. Do not delete `HERMES_HOME`.
+
+If a schema migration or profile issue is suspected, make a profile backup
+before rollback. Restore only from a snapshot produced for that profile and
+release train. Application rollback and profile-data restoration are separate
+operations.

--- a/downstream/distribution.json
+++ b/downstream/distribution.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "id": "hermes-agent-windows",
+  "display_name": "Hermes Agent Windows Workstation Edition",
+  "version": "0.20.5-win.1",
+  "repository": {
+    "slug": "zapabob/hermes-agent-windows",
+    "web": "https://github.com/zapabob/hermes-agent-windows",
+    "https": "https://github.com/zapabob/hermes-agent-windows.git",
+    "ssh": "git@github.com:zapabob/hermes-agent-windows.git",
+    "raw_base": "https://raw.githubusercontent.com/zapabob/hermes-agent-windows",
+    "archive_base": "https://github.com/zapabob/hermes-agent-windows/archive"
+  },
+  "upstream": {
+    "slug": "NousResearch/hermes-agent",
+    "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802"
+  },
+  "platform": {
+    "os": "windows",
+    "architectures": [
+      "x64"
+    ],
+    "tier": 1
+  },
+  "channels": {
+    "default": "stable",
+    "supported": [
+      "stable",
+      "preview"
+    ]
+  },
+  "update": {
+    "branch": "main",
+    "allow_upstream_sync": false
+  }
+}

--- a/downstream/distribution.py
+++ b/downstream/distribution.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+import json
+from pathlib import Path
+import re
+import subprocess
+from urllib.parse import quote
+
+
+_METADATA_PATH = Path(__file__).with_name("distribution.json")
+_FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+@dataclass(frozen=True)
+class RepositoryMetadata:
+    slug: str
+    web: str
+    https: str
+    ssh: str
+    raw_base: str
+    archive_base: str
+
+
+@dataclass(frozen=True)
+class UpstreamMetadata:
+    slug: str
+    snapshot_sha: str
+
+
+@dataclass(frozen=True)
+class PlatformMetadata:
+    os: str
+    architectures: tuple[str, ...]
+    tier: int
+
+
+@dataclass(frozen=True)
+class ChannelMetadata:
+    default: str
+    supported: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class UpdateMetadata:
+    branch: str
+    allow_upstream_sync: bool
+
+
+@dataclass(frozen=True)
+class DistributionMetadata:
+    schema_version: int
+    id: str
+    display_name: str
+    version: str
+    repository: RepositoryMetadata
+    upstream: UpstreamMetadata
+    platform: PlatformMetadata
+    channels: ChannelMetadata
+    update: UpdateMetadata
+
+
+def _require_mapping(value: object, field: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"distribution field {field!r} must be an object")
+    return value
+
+
+def _require_string(mapping: dict[str, object], field: str) -> str:
+    value = mapping.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"distribution field {field!r} must be a non-empty string")
+    return value.strip()
+
+
+@lru_cache(maxsize=1)
+def load_distribution(path: Path | None = None) -> DistributionMetadata:
+    metadata_path = path or _METADATA_PATH
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    root = _require_mapping(payload, "root")
+    repository = _require_mapping(root.get("repository"), "repository")
+    upstream = _require_mapping(root.get("upstream"), "upstream")
+    platform = _require_mapping(root.get("platform"), "platform")
+    channels = _require_mapping(root.get("channels"), "channels")
+    update = _require_mapping(root.get("update"), "update")
+
+    snapshot_sha = _require_string(upstream, "snapshot_sha").lower()
+    if not _FULL_SHA.fullmatch(snapshot_sha):
+        raise ValueError("upstream.snapshot_sha must be a 40-character lowercase SHA")
+
+    architectures = platform.get("architectures")
+    if (
+        not isinstance(architectures, list)
+        or not architectures
+        or not all(isinstance(item, str) and item for item in architectures)
+    ):
+        raise ValueError("platform.architectures must be a non-empty string list")
+    supported = channels.get("supported")
+    if (
+        not isinstance(supported, list)
+        or not supported
+        or not all(isinstance(item, str) and item for item in supported)
+    ):
+        raise ValueError("channels.supported must be a non-empty string list")
+    default_channel = _require_string(channels, "default")
+    if default_channel not in supported:
+        raise ValueError("channels.default must be present in channels.supported")
+    allow_upstream_sync = update.get("allow_upstream_sync")
+    if not isinstance(allow_upstream_sync, bool):
+        raise ValueError("update.allow_upstream_sync must be a boolean")
+
+    return DistributionMetadata(
+        schema_version=int(root.get("schema_version", 0)),
+        id=_require_string(root, "id"),
+        display_name=_require_string(root, "display_name"),
+        version=_require_string(root, "version"),
+        repository=RepositoryMetadata(
+            slug=_require_string(repository, "slug"),
+            web=_require_string(repository, "web"),
+            https=_require_string(repository, "https"),
+            ssh=_require_string(repository, "ssh"),
+            raw_base=_require_string(repository, "raw_base").rstrip("/"),
+            archive_base=_require_string(repository, "archive_base").rstrip("/"),
+        ),
+        upstream=UpstreamMetadata(
+            slug=_require_string(upstream, "slug"),
+            snapshot_sha=snapshot_sha,
+        ),
+        platform=PlatformMetadata(
+            os=_require_string(platform, "os"),
+            architectures=tuple(architectures),
+            tier=int(platform.get("tier", 0)),
+        ),
+        channels=ChannelMetadata(
+            default=default_channel,
+            supported=tuple(supported),
+        ),
+        update=UpdateMetadata(
+            branch=_require_string(update, "branch"),
+            allow_upstream_sync=allow_upstream_sync,
+        ),
+    )
+
+
+def install_script_url(ref: str, script_name: str) -> str:
+    distribution = load_distribution()
+    return (
+        f"{distribution.repository.raw_base}/{quote(ref, safe='/')}/scripts/"
+        f"{quote(script_name, safe='')}"
+    )
+
+
+def update_archive_url(branch: str) -> str:
+    distribution = load_distribution()
+    return (
+        f"{distribution.repository.archive_base}/refs/heads/"
+        f"{quote(branch, safe='/')}.zip"
+    )
+
+
+def resolve_downstream_sha(project_root: Path | None = None) -> str | None:
+    root = project_root or _METADATA_PATH.parents[1]
+    build_sha = root / ".hermes_build_sha"
+    try:
+        stamped = build_sha.read_text(encoding="utf-8").strip().lower()
+        if _FULL_SHA.fullmatch(stamped):
+            return stamped
+    except OSError:
+        pass
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    sha = result.stdout.strip().lower()
+    return sha if result.returncode == 0 and _FULL_SHA.fullmatch(sha) else None
+
+
+def distribution_version_lines(
+    *, downstream_sha: str | None = None
+) -> tuple[str, str, str, str]:
+    distribution = load_distribution()
+    resolved_sha = downstream_sha or resolve_downstream_sha()
+    revision = resolved_sha[:12] if resolved_sha else "unknown"
+    return (
+        f"Distribution: {distribution.display_name} {distribution.version}",
+        f"Frozen upstream: {distribution.upstream.snapshot_sha[:12]}",
+        f"Downstream revision: {revision}",
+        f"Update channel: {distribution.channels.default}",
+    )

--- a/downstream/release_notes.py
+++ b/downstream/release_notes.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import subprocess
+from typing import Any
+
+import yaml
+
+
+DOWNSTREAM_TAG = re.compile(r"^v\d+\.\d+\.\d+-win\.\d+$")
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    value = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return value if isinstance(value, dict) else {}
+
+
+def _git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    )
+    return result.stdout.strip()
+
+
+def resolve_previous_downstream_tag(repo_root: Path, current_tag: str) -> str | None:
+    tags = _git(
+        repo_root,
+        "tag",
+        "--merged",
+        "HEAD",
+        "--list",
+        "v*.*.*-win.*",
+        "--sort=-version:refname",
+    ).splitlines()
+    return next(
+        (tag for tag in tags if tag != current_tag and DOWNSTREAM_TAG.fullmatch(tag)),
+        None,
+    )
+
+
+def read_commit_history(
+    repo_root: Path, previous_tag: str | None
+) -> list[dict[str, Any]]:
+    if not previous_tag:
+        return []
+    raw = _git(repo_root, "log", "--format=%H%x1f%s", f"{previous_tag}..HEAD")
+    commits: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        sha, separator, subject = line.partition("\x1f")
+        if not separator:
+            continue
+        paths = _git(
+            repo_root,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            sha,
+        ).splitlines()
+        commits.append({"sha": sha, "subject": subject, "paths": paths})
+    return commits
+
+
+def _matches(commit: dict[str, Any], terms: tuple[str, ...]) -> bool:
+    text = " ".join([
+        str(commit.get("subject", "")),
+        *map(str, commit.get("paths", [])),
+    ]).lower()
+    return any(term in text for term in terms)
+
+
+def _commit_lines(commits: list[dict[str, Any]], terms: tuple[str, ...]) -> list[str]:
+    selected = [commit for commit in commits if _matches(commit, terms)]
+    if not selected:
+        return ["- No categorized changes in this release range."]
+    return [f"- `{str(commit['sha'])[:12]}` {commit['subject']}" for commit in selected]
+
+
+def render_release_notes(
+    *,
+    manifest: dict[str, Any],
+    features: dict[str, Any],
+    carry: dict[str, Any],
+    adoption: dict[str, Any],
+    snapshot: dict[str, Any],
+    commits: list[dict[str, Any]],
+    previous_tag: str | None,
+) -> str:
+    verified_windows_features = sorted(
+        str(feature.get("id"))
+        for feature in features.get("features", [])
+        if isinstance(feature, dict)
+        and feature.get("status") == "verified"
+        and feature.get("windows_required") is True
+    )
+    carry_count = len([
+        entry for entry in carry.get("carry", []) if isinstance(entry, dict)
+    ])
+    category_counts = adoption.get("category_counts", {})
+    critical_count = int(category_counts.get("SECURITY_CRITICAL", 0))
+    upstream_sha = str(
+        snapshot.get("upstream_head_sha") or manifest["upstream_snapshot_sha"]
+    )
+    signing = "Signed" if manifest["installer_signed"] else "Unsigned"
+    real_workstation = manifest["windows_qualification"].get(
+        "real_workstation_qualified", False
+    )
+    lines = [
+        f"# {manifest['product_name']} {manifest['downstream_version']}",
+        "",
+        "This is an unofficial Windows-first downstream distribution of Hermes Agent.",
+        "It is not affiliated with or endorsed by Nous Research.",
+        "",
+        f"Release channel: {manifest['release_channel']}",
+        f"Downstream commit: `{manifest['downstream_commit_sha']}`",
+        f"Frozen upstream snapshot: `{upstream_sha}`",
+        f"Windows CI qualification: {manifest['windows_qualification']['status']}",
+        f"Real workstation qualification: {'passed' if real_workstation else 'not qualified'}",
+        f"Installer signature: {signing}",
+        f"Provenance attestation: {manifest['attestation_status']}",
+        "",
+        "## Windows Workstation changes",
+        "",
+        f"Verified Windows-required capabilities: {', '.join(verified_windows_features)}.",
+        f"Direct upstream-file carry entries: {carry_count}.",
+        "",
+        *_commit_lines(
+            commits,
+            (
+                "windows",
+                "installer",
+                "portable",
+                "watchdog",
+                "distribution",
+                "release",
+            ),
+        ),
+        "",
+        "## Upstream snapshot",
+        "",
+        f"This release is based on exact upstream commit `{upstream_sha}`.",
+        f"Adoption decisions: {json.dumps(adoption.get('decision_counts', {}), sort_keys=True)}.",
+        "Commits after that frozen snapshot are outside this release train.",
+        "",
+        "## Security",
+        "",
+        f"The frozen upstream audit classified {critical_count} commits as security-critical.",
+        *_commit_lines(
+            commits,
+            ("security", "cve", "credential", "approval", "auth", "lock"),
+        ),
+        "",
+        "## Bug fixes",
+        "",
+        *_commit_lines(commits, ("fix", "bug", "regression")),
+        "",
+        "## Local AI",
+        "",
+        *_commit_lines(
+            commits,
+            ("llama", "gguf", "embedding", "local-ai", "local_provider", "model"),
+        ),
+        "",
+        "## Desktop",
+        "",
+        *_commit_lines(commits, ("apps/desktop", "electron", "desktop")),
+        "",
+        "## Memory",
+        "",
+        *_commit_lines(
+            commits, ("memory", "semantic_graph", "semantic-graph", "ebbinghaus")
+        ),
+        "",
+        "## Voice / VR / Unity",
+        "",
+        *_commit_lines(commits, ("voice", "tts", "vrchat", "unity", "aituber")),
+        "",
+        "## Known limitations",
+        "",
+        f"- Installer Authenticode status: {signing}.",
+        f"- Physical workstation qualification: {'passed' if real_workstation else 'not recorded as passed'}.",
+        "- GGUF model weights are not included in the default release artifacts.",
+        (
+            f"- Changes are measured from downstream tag `{previous_tag}`."
+            if previous_tag
+            else "- No earlier downstream Windows tag is recorded; this is the first release range."
+        ),
+        "",
+        "## Artifact hashes",
+        "",
+    ]
+    for artifact in manifest["artifacts"]:
+        lines.append(f"- `{artifact['sha256']}`  `{artifact['name']}`")
+    lines.extend([
+        "",
+        "Verify downloads against `SHA256SUMS.txt` before installation.",
+        "Updates resolve only from the downstream repository and selected release channel.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def build_release_notes(
+    manifest: dict[str, Any], repo_root: Path, previous_tag: str | None = None
+) -> str:
+    current_tag = f"v{manifest['downstream_version']}"
+    baseline_tag = previous_tag or resolve_previous_downstream_tag(
+        repo_root, current_tag
+    )
+    return render_release_notes(
+        manifest=manifest,
+        features=_read_yaml(repo_root / "FEATURES.yaml"),
+        carry=_read_yaml(repo_root / "CARRY.yaml"),
+        adoption=_read_yaml(repo_root / "UPSTREAM_ADOPTION.yaml"),
+        snapshot=json.loads(
+            (repo_root / ".codex" / "UPSTREAM_SNAPSHOT.json").read_text(
+                encoding="utf-8"
+            )
+        ),
+        commits=read_commit_history(repo_root, baseline_tag),
+        previous_tag=baseline_tag,
+    )

--- a/hermes_cli/_startup_fast.py
+++ b/hermes_cli/_startup_fast.py
@@ -203,6 +203,14 @@ def print_fast_version_info(*, check_updates: bool = True) -> None:
 
         print(f"Hermes Agent v{__version__} ({__release_date__})")
 
+    try:
+        from downstream.distribution import distribution_version_lines
+
+        for line in distribution_version_lines():
+            print(line)
+    except Exception:
+        pass
+
     print(f"Install directory: {project_root_str()}")
 
     # Install method: authoritative resolver first (code-scoped stamp →

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -1533,9 +1533,7 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         )
         _m().sys.exit(1)
     _abort_zip_update_if_dirty_tree()
-    zip_url = (
-        f"https://github.com/NousResearch/hermes-agent/archive/refs/heads/{branch}.zip"
-    )
+    zip_url = _distribution_archive_url(branch)
 
     print("→ Downloading latest version...")
     tmp_dir = tempfile.mkdtemp(prefix="hermes-update-")
@@ -2288,6 +2286,39 @@ OFFICIAL_REPO_URL = "https://github.com/NousResearch/hermes-agent.git"
 
 SKIP_UPSTREAM_PROMPT_FILE = ".skip_upstream_prompt"
 
+
+def _normalize_repo_url(url: str) -> str:
+    normalized = url.strip().rstrip("/").lower()
+    return normalized[:-4] if normalized.endswith(".git") else normalized
+
+
+def _distribution_repo_urls() -> set[str]:
+    from downstream.distribution import load_distribution
+
+    repository = load_distribution().repository
+    return {repository.web, repository.https, repository.ssh}
+
+
+def _is_distribution_origin(origin_url: Optional[str]) -> bool:
+    if not origin_url:
+        return False
+    normalized = _normalize_repo_url(origin_url)
+    return any(
+        normalized == _normalize_repo_url(candidate)
+        for candidate in _distribution_repo_urls()
+    )
+
+
+def _distribution_archive_url(branch: str) -> str:
+    try:
+        from downstream.distribution import update_archive_url
+
+        return update_archive_url(branch)
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        raise RuntimeError(
+            "downstream distribution metadata is required for ZIP updates"
+        ) from exc
+
 def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
     """Get the URL of the origin remote, or None if not set."""
     try:
@@ -2306,6 +2337,8 @@ def _get_origin_url(git_cmd: list[str], cwd: Path) -> Optional[str]:
 def _is_fork(origin_url: Optional[str]) -> bool:
     """Check if the origin remote points to a fork (not the official repo)."""
     if not origin_url:
+        return False
+    if _is_distribution_origin(origin_url):
         return False
     # Normalize URL for comparison (strip trailing .git if present)
     normalized = origin_url.rstrip("/")
@@ -3379,7 +3412,8 @@ def _cmd_update_check(branch: str = "main", *, branch_explicit: bool = False):
     )
     depth_args = ["--depth", "1"] if is_shallow else []
 
-    if branch == "main":
+    origin_url = _get_origin_url(git_cmd, _m().PROJECT_ROOT)
+    if branch == "main" and not _is_distribution_origin(origin_url):
         # Probe locally (~6 ms) whether an 'upstream' remote exists at all
         # before spending a network fetch on it. Non-fork installs have no
         # 'upstream' remote, and the old flow burned a failed network attempt

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
     },
     "apps/desktop": {
       "name": "hermes",
-      "version": "0.17.0",
+      "version": "0.20.5-win.1",
       "dependencies": {
         "@assistant-ui/core": "0.2.23",
         "@assistant-ui/react": "0.14.24",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -461,7 +461,7 @@ gateway = ["assets/**/*"]
 # sealed wheels with the plugin Python modules; without this declaration the
 # wheel contains adapters but discovery finds zero bundled plugins.
 plugins = ["**/plugin.yaml", "**/plugin.yml"]
-downstream = ["security/*.json", "security/rules/*.yar"]
+downstream = ["distribution.json", "security/*.json", "security/rules/*.yar"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/demo/windows-demo.ps1
+++ b/scripts/demo/windows-demo.ps1
@@ -1,0 +1,352 @@
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\.." )).Path,
+    [string]$InstallerPath = "",
+    [string]$DemoRoot = (Join-Path $env:TEMP "Hermes Windows Workstation Demo $([guid]::NewGuid())"),
+    [string]$ModelId = "local-model",
+    [string]$LlamaBaseUrl = "http://127.0.0.1:8080/v1",
+    [string]$ConversationPrompt = "Reply with the product name and one short sentence.",
+    [int]$WatchdogPort = 19920,
+    [int]$BackendPort = 19119,
+    [switch]$RunConversation,
+    [switch]$ExerciseRecovery,
+    [switch]$AllowPartial,
+    [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path -LiteralPath $RepoRoot).Path
+$demo = [System.IO.Path]::GetFullPath($DemoRoot)
+if (Test-Path -LiteralPath $demo) {
+    throw "DemoRoot already exists; choose a new dedicated directory: $demo"
+}
+$profileHome = Join-Path $demo "profile"
+$installRoot = Join-Path $demo "installed"
+$watchdogData = Join-Path $demo "watchdog"
+$reportPath = if ($OutputPath) {
+    [System.IO.Path]::GetFullPath($OutputPath)
+} else {
+    Join-Path $demo "windows-demo.json"
+}
+New-Item -ItemType Directory -Path $profileHome, $watchdogData -Force | Out-Null
+
+$llamaUri = [Uri]$LlamaBaseUrl
+if (-not $llamaUri.IsLoopback) {
+    throw "The demo accepts only a loopback local-model endpoint"
+}
+if ($ModelId -match "[\r\n]") {
+    throw "ModelId must be one line"
+}
+
+function Test-HttpEndpoint {
+    param([string]$Uri, [int]$TimeoutSec = 5)
+    try {
+        $response = Invoke-WebRequest -Uri $Uri -UseBasicParsing -TimeoutSec $TimeoutSec
+        return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300)
+    } catch {
+        return $false
+    }
+}
+
+function Wait-HttpEndpoint {
+    param([string]$Uri, [int]$TimeoutSec)
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSec)
+    do {
+        if (Test-HttpEndpoint $Uri) {
+            return $true
+        }
+        Start-Sleep -Seconds 2
+    } while ([DateTime]::UtcNow -lt $deadline)
+    return $false
+}
+
+function Get-SessionIdFromText {
+    param([string]$Text)
+    $match = [regex]::Match(
+        $Text,
+        "[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+    )
+    return if ($match.Success) { $match.Value } else { "" }
+}
+
+$python = Join-Path $root ".venv\Scripts\python.exe"
+if (-not (Test-Path -LiteralPath $python)) {
+    $sharedVenvPython = [System.IO.Path]::GetFullPath(
+        (Join-Path $root "..\..\.venv\Scripts\python.exe")
+    )
+    if (Test-Path -LiteralPath $sharedVenvPython) {
+        $python = $sharedVenvPython
+    } else {
+        $python = (Get-Command python -ErrorAction Stop).Source
+    }
+}
+$distribution = Get-Content -LiteralPath (Join-Path $root "downstream\distribution.json") -Raw |
+    ConvertFrom-Json
+$downstreamSha = (& git -C $root rev-parse HEAD).Trim()
+$results = [ordered]@{
+    clean_install = "not_run"
+    cli_version = "failed"
+    desktop_launch = "not_run"
+    local_agent_conversation = "not_run"
+    local_llama_provider = "failed"
+    watchdog_status = "not_run"
+    supervised_backend_recovery = "not_run"
+    session_persistence = "not_run"
+    downstream_identity = "failed"
+}
+$desktop = $null
+$demoDesktopProcess = $null
+$watchdogProcess = $null
+$previousHermesHome = [Environment]::GetEnvironmentVariable("HERMES_HOME", "Process")
+$previousFallbackAutostart = [Environment]::GetEnvironmentVariable(
+    "HERMES_LLAMA_FALLBACK_AUTOSTART",
+    "Process"
+)
+
+try {
+    [Environment]::SetEnvironmentVariable("HERMES_HOME", $profileHome, "Process")
+    [Environment]::SetEnvironmentVariable(
+        "HERMES_LLAMA_FALLBACK_AUTOSTART",
+        "false",
+        "Process"
+    )
+    $modelYaml = ConvertTo-Json $ModelId -Compress
+    $baseUrlYaml = ConvertTo-Json $LlamaBaseUrl -Compress
+    $config = @(
+        "model:",
+        "  provider: custom",
+        "  default: $modelYaml",
+        "  base_url: $baseUrlYaml",
+        "  api_key: local",
+        "  api_mode: chat_completions"
+    ) -join [Environment]::NewLine
+    [System.IO.File]::WriteAllText(
+        (Join-Path $profileHome "config.yaml"),
+        ($config + [Environment]::NewLine),
+        [System.Text.UTF8Encoding]::new($false)
+    )
+
+    if ($InstallerPath) {
+        $installer = (Resolve-Path -LiteralPath $InstallerPath).Path
+        New-Item -ItemType Directory -Path $installRoot -Force | Out-Null
+        $installerProcess = Start-Process -FilePath $installer `
+            -ArgumentList @("/S", "/D=$installRoot") `
+            -Wait `
+            -PassThru `
+            -WindowStyle Hidden
+        if ($installerProcess.ExitCode -ne 0) {
+            throw "Installer exited with code $($installerProcess.ExitCode)"
+        }
+        $desktop = Get-ChildItem -LiteralPath $installRoot -Filter "Hermes.exe" -File -Recurse |
+            Select-Object -First 1
+        if (-not $desktop) {
+            throw "The dedicated demo installation does not contain Hermes.exe"
+        }
+        $resourceRoot = Join-Path $desktop.Directory.FullName "resources"
+        $packagedDistributionPath = Join-Path $resourceRoot "distribution\distribution.json"
+        $installStampPath = Join-Path $resourceRoot "install-stamp.json"
+        if (
+            -not (Test-Path -LiteralPath $packagedDistributionPath) -or
+            -not (Test-Path -LiteralPath $installStampPath)
+        ) {
+            throw "The demo installation is missing distribution or exact-SHA metadata"
+        }
+        $packagedDistribution = Get-Content -LiteralPath $packagedDistributionPath -Raw |
+            ConvertFrom-Json
+        $installStamp = Get-Content -LiteralPath $installStampPath -Raw | ConvertFrom-Json
+        $desktopVersion = (Get-Item -LiteralPath $desktop.FullName).VersionInfo
+        if (
+            $packagedDistribution.id -ne $distribution.id -or
+            $packagedDistribution.version -ne $distribution.version -or
+            $desktopVersion.InternalName -ne $distribution.id -or
+            $desktopVersion.SpecialBuild -ne $distribution.version -or
+            $installStamp.commit -ne $downstreamSha -or
+            $installStamp.dirty -ne $false
+        ) {
+            throw "The installed Desktop identity does not match the exact clean candidate"
+        }
+        $results.clean_install = "passed"
+        $results.downstream_identity = "passed"
+    }
+
+    $versionText = (& $python -m hermes_cli.main --version 2>&1 | Out-String).Trim()
+    if ($LASTEXITCODE -eq 0 -and $versionText -match [regex]::Escape($distribution.version)) {
+        $results.cli_version = "passed"
+    }
+
+    if ($desktop) {
+        $demoDesktopProcess = Start-Process -FilePath $desktop.FullName `
+            -PassThru `
+            -WindowStyle Hidden
+        Start-Sleep -Seconds 8
+        $results.desktop_launch = if ($demoDesktopProcess.HasExited) { "failed" } else { "passed" }
+    }
+
+    $modelsUrl = $LlamaBaseUrl.TrimEnd("/") + "/models"
+    $results.local_llama_provider = if (Test-HttpEndpoint $modelsUrl) {
+        "passed"
+    } else {
+        "failed"
+    }
+
+    $sessionBeforeRecovery = ""
+    if ($RunConversation -and $results.local_llama_provider -eq "passed") {
+        & $python -m hermes_cli.main `
+            --ignore-rules `
+            --provider custom `
+            --model $ModelId `
+            chat `
+            --query $ConversationPrompt
+        if ($LASTEXITCODE -eq 0) {
+            $results.local_agent_conversation = "passed"
+            $sessionList = (& $python -m hermes_cli.main sessions list --limit 20 2>&1 | Out-String)
+            $sessionBeforeRecovery = Get-SessionIdFromText $sessionList
+        } else {
+            $results.local_agent_conversation = "failed"
+        }
+    }
+
+    if ($ExerciseRecovery) {
+        if (-not $desktop) {
+            throw "ExerciseRecovery requires InstallerPath"
+        }
+        $foreignDesktop = @(Get-CimInstance Win32_Process -Filter "Name = 'Hermes.exe'" |
+            Where-Object {
+                $_.ExecutablePath -and
+                -not $_.ExecutablePath.StartsWith(
+                    $installRoot,
+                    [System.StringComparison]::OrdinalIgnoreCase
+                )
+            })
+        if ($foreignDesktop.Count -gt 0) {
+            throw "Recovery demo requires a clean workstation without another Hermes.exe"
+        }
+        $watchdogExe = Join-Path $root "scripts\windows\watchdog-go\dist\hermes-watchdog.exe"
+        if (-not (Test-Path -LiteralPath $watchdogExe)) {
+            & powershell.exe -NoProfile -ExecutionPolicy Bypass -File `
+                (Join-Path $root "scripts\windows\Build-HermesGoWatchdog.ps1")
+            if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $watchdogExe)) {
+                throw "Could not build the dedicated demo watchdog"
+            }
+        }
+        $watchdogUrl = "http://127.0.0.1:$WatchdogPort/api/status"
+        $backendUrl = "http://127.0.0.1:$BackendPort/api/status"
+        if ((Test-HttpEndpoint $watchdogUrl) -or (Test-HttpEndpoint $backendUrl)) {
+            throw "Dedicated demo ports are already in use"
+        }
+        $watchdogArguments = @(
+            "-hermes-root", ('"' + $root + '"'),
+            "-hermes-home", ('"' + $profileHome + '"'),
+            "-packaged-exe", ('"' + $desktop.FullName + '"'),
+            "-data-dir", ('"' + $watchdogData + '"'),
+            "-listen", "127.0.0.1:$WatchdogPort",
+            "-managed-backend-port", "$BackendPort",
+            "-interval", "2",
+            "-fail-threshold", "2"
+        )
+        $watchdogProcess = Start-Process -FilePath $watchdogExe `
+            -ArgumentList $watchdogArguments `
+            -PassThru `
+            -WindowStyle Hidden
+        if (-not (Wait-HttpEndpoint $watchdogUrl 30)) {
+            throw "Dedicated watchdog did not become ready"
+        }
+        if ($watchdogProcess.HasExited) {
+            throw "Dedicated watchdog exited before qualification"
+        }
+        if (-not (Wait-HttpEndpoint $backendUrl 180)) {
+            throw "Dedicated managed backend did not become ready"
+        }
+        $results.watchdog_status = "passed"
+        $before = Invoke-RestMethod -Uri $watchdogUrl -TimeoutSec 5
+        $backendPid = [int]$before.backendPid
+        if ($backendPid -le 0) {
+            throw "Dedicated watchdog did not report a managed backend PID"
+        }
+        Stop-Process -Id $backendPid -Force
+        $recovered = $false
+        $deadline = [DateTime]::UtcNow.AddSeconds(180)
+        do {
+            Start-Sleep -Seconds 2
+            try {
+                $after = Invoke-RestMethod -Uri $watchdogUrl -TimeoutSec 5
+                $newPid = [int]$after.backendPid
+                if ($newPid -gt 0 -and $newPid -ne $backendPid -and (Test-HttpEndpoint $backendUrl)) {
+                    $recovered = $true
+                    break
+                }
+            } catch {}
+        } while ([DateTime]::UtcNow -lt $deadline)
+        $results.supervised_backend_recovery = if ($recovered) { "passed" } else { "failed" }
+        if ($sessionBeforeRecovery) {
+            $sessionListAfter = (& $python -m hermes_cli.main sessions list --limit 20 2>&1 | Out-String)
+            $results.session_persistence = if (
+                $sessionListAfter -match [regex]::Escape($sessionBeforeRecovery)
+            ) { "passed" } else { "failed" }
+        }
+    }
+} finally {
+    if ($watchdogProcess -and -not $watchdogProcess.HasExited) {
+        Stop-Process -Id $watchdogProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+    if ($demoDesktopProcess -and -not $demoDesktopProcess.HasExited) {
+        Stop-Process -Id $demoDesktopProcess.Id -Force -ErrorAction SilentlyContinue
+    }
+    if (Test-Path -LiteralPath $installRoot) {
+        $ownedRoot = [System.IO.Path]::GetFullPath($installRoot).TrimEnd('\') + '\'
+        $ownedProcesses = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue |
+            Where-Object {
+                $_.ExecutablePath -and
+                $_.ExecutablePath.StartsWith(
+                    $ownedRoot,
+                    [System.StringComparison]::OrdinalIgnoreCase
+                )
+            })
+        if ($ownedProcesses.Count -gt 0) {
+            Stop-Process -Id @($ownedProcesses.ProcessId) -Force -ErrorAction SilentlyContinue
+        }
+    }
+    [Environment]::SetEnvironmentVariable("HERMES_HOME", $previousHermesHome, "Process")
+    [Environment]::SetEnvironmentVariable(
+        "HERMES_LLAMA_FALLBACK_AUTOSTART",
+        $previousFallbackAutostart,
+        "Process"
+    )
+}
+
+$required = @(
+    "clean_install", "cli_version", "desktop_launch", "local_llama_provider",
+    "downstream_identity"
+)
+if ($RunConversation) {
+    $required += "local_agent_conversation"
+}
+if ($ExerciseRecovery) {
+    $required += @("watchdog_status", "supervised_backend_recovery", "session_persistence")
+}
+$status = if (@($required | Where-Object { $results[$_] -ne "passed" }).Count -eq 0) {
+    "passed"
+} else {
+    "failed"
+}
+$report = [ordered]@{
+    schema_version = 1
+    status = $status
+    downstream_commit_sha = $downstreamSha
+    upstream_snapshot_sha = [string]$distribution.upstream.snapshot_sha
+    distribution_version = [string]$distribution.version
+    dedicated_demo_profile = $true
+    results = $results
+}
+$reportDirectory = Split-Path -Parent $reportPath
+if ($reportDirectory) {
+    New-Item -ItemType Directory -Path $reportDirectory -Force | Out-Null
+}
+[System.IO.File]::WriteAllText(
+    $reportPath,
+    (($report | ConvertTo-Json -Depth 8) + [Environment]::NewLine),
+    [System.Text.UTF8Encoding]::new($false)
+)
+$report | ConvertTo-Json -Depth 8
+if ($status -ne "passed" -and -not $AllowPartial) {
+    throw "Windows demo failed or remains incomplete"
+}

--- a/scripts/downstream/generate_release_manifest.py
+++ b/scripts/downstream/generate_release_manifest.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import shutil
+from typing import Any
+
+from downstream.distribution import load_distribution, resolve_downstream_sha
+from downstream.release_notes import build_release_notes
+
+
+REQUIRED_STABLE_GATES = (
+    "install_e2e",
+    "portable_e2e",
+    "upgrade_e2e",
+    "windows_native_python",
+    "windows_native_desktop",
+    "watchdog_go",
+    "upstream_api_compat",
+    "windows_regression",
+    "security_locks",
+)
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _artifact(path: Path, kind: str, *, signed: bool | None = None) -> dict[str, Any]:
+    artifact: dict[str, Any] = {
+        "kind": kind,
+        "name": path.name,
+        "size_bytes": path.stat().st_size,
+        "sha256": _sha256(path),
+    }
+    if signed is not None:
+        artifact["signed"] = signed
+    return artifact
+
+
+def _validate_qualification(
+    qualification: dict[str, Any], channel: str, downstream_sha: str
+) -> None:
+    if channel != "stable":
+        return
+    gates = qualification.get("gates", {})
+    missing = [name for name in REQUIRED_STABLE_GATES if gates.get(name) != "passed"]
+    sha_matches = qualification.get("downstream_commit_sha") == downstream_sha
+    ci_qualified = qualification.get("ci_qualified") is True
+    if (
+        qualification.get("status") != "passed"
+        or missing
+        or not sha_matches
+        or not ci_qualified
+    ):
+        if not sha_matches:
+            missing.append("exact_downstream_sha")
+        if not ci_qualified:
+            missing.append("ci_qualified")
+        details = ", ".join(missing) if missing else "overall status"
+        raise ValueError(
+            f"stable release requires passed qualification gates: {details}"
+        )
+
+
+def generate_release_bundle(
+    *,
+    installer: Path,
+    portable: Path,
+    qualification: dict[str, Any],
+    output_dir: Path,
+    channel: str,
+    downstream_sha: str,
+    installer_signed: bool,
+    build_timestamp_utc: str | None = None,
+    attestation_status: str = "not_generated",
+) -> dict[str, Any]:
+    distribution = load_distribution()
+    if channel not in distribution.channels.supported:
+        raise ValueError(f"unsupported release channel: {channel}")
+    if not FULL_SHA.fullmatch(downstream_sha):
+        raise ValueError("downstream SHA must be a 40-character lowercase SHA")
+    if not installer.is_file() or not portable.is_file():
+        raise FileNotFoundError("installer and portable artifacts are required")
+    _validate_qualification(qualification, channel, downstream_sha)
+    if channel == "stable" and attestation_status != "generated":
+        raise ValueError("stable release requires generated provenance attestation")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    prefix = f"Hermes-Agent-Windows-{distribution.version}-x64"
+    published_installer = output_dir / f"{prefix}-Setup.exe"
+    published_portable = output_dir / f"{prefix}-portable.zip"
+    shutil.copy2(installer, published_installer)
+    shutil.copy2(portable, published_portable)
+
+    artifacts = [
+        _artifact(published_installer, "installer", signed=installer_signed),
+        _artifact(published_portable, "portable"),
+    ]
+    timestamp = build_timestamp_utc or datetime.now(timezone.utc).replace(
+        microsecond=0
+    ).isoformat().replace("+00:00", "Z")
+    manifest: dict[str, Any] = {
+        "schema_version": 1,
+        "product_name": distribution.display_name,
+        "distribution_id": distribution.id,
+        "downstream_version": distribution.version,
+        "downstream_commit_sha": downstream_sha,
+        "upstream_snapshot_sha": distribution.upstream.snapshot_sha,
+        "build_timestamp_utc": timestamp,
+        "release_channel": channel,
+        "architecture": distribution.platform.architectures[0],
+        "artifacts": artifacts,
+        "installer_signed": installer_signed,
+        "portable_artifact": published_portable.name,
+        "windows_qualification": {
+            "status": qualification.get("status", "unknown"),
+            "schema_version": qualification.get("schema_version", 0),
+            "ci_qualified": qualification.get("ci_qualified", False),
+            "real_workstation_qualified": qualification.get(
+                "real_workstation_qualified", False
+            ),
+        },
+        "attestation_status": attestation_status,
+    }
+
+    manifest_path = output_dir / "release-manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    sums = "".join(f"{item['sha256']}  {item['name']}\n" for item in artifacts)
+    (output_dir / "SHA256SUMS.txt").write_text(sums, encoding="utf-8")
+    (output_dir / "RELEASE_NOTES.md").write_text(
+        build_release_notes(manifest, Path(__file__).resolve().parents[2]),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--installer", type=Path, required=True)
+    parser.add_argument("--portable", type=Path, required=True)
+    parser.add_argument("--qualification", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--channel", choices=("stable", "preview"), required=True)
+    parser.add_argument("--downstream-sha", default="")
+    parser.add_argument("--installer-signed", choices=("true", "false"), required=True)
+    parser.add_argument("--attestation-status", default="not_generated")
+    args = parser.parse_args()
+
+    qualification = json.loads(args.qualification.read_text(encoding="utf-8"))
+    downstream_sha = args.downstream_sha or resolve_downstream_sha()
+    if not downstream_sha:
+        raise SystemExit("could not resolve downstream commit SHA")
+    generate_release_bundle(
+        installer=args.installer,
+        portable=args.portable,
+        qualification=qualification,
+        output_dir=args.output_dir,
+        channel=args.channel,
+        downstream_sha=downstream_sha,
+        installer_signed=args.installer_signed == "true",
+        attestation_status=args.attestation_status,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/downstream/generate_release_notes.py
+++ b/scripts/downstream/generate_release_notes.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from downstream.release_notes import build_release_notes
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--previous-tag", default="")
+    args = parser.parse_args()
+    manifest = json.loads(args.manifest.read_text(encoding="utf-8"))
+    notes = build_release_notes(
+        manifest,
+        args.repo_root.resolve(),
+        previous_tag=args.previous_tag or None,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(notes, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,7 +5,7 @@
 # Uses uv for fast Python provisioning and package management.
 #
 # Usage:
-#   iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+#   iex (irm https://raw.githubusercontent.com/zapabob/hermes-agent-windows/main/scripts/install.ps1)
 #
 # Or download and run with options:
 #   .\install.ps1 -NoVenv -SkipSetup
@@ -17,6 +17,9 @@ param(
     [switch]$SkipSetup,
     [switch]$SkipComputerUse,
     [string]$Branch = "main",
+    [string]$RepositoryUrlHttps = "",
+    [string]$RepositoryUrlSsh = "",
+    [string]$RepositoryArchiveBase = "",
     # -Commit and -Tag are higher-precedence variants of -Branch for users
     # who need reproducible installs (desktop installer pinning, CI, release
     # bundles).  When set, the repository stage clones $Branch (faster than
@@ -383,8 +386,56 @@ $script:ResolvedPathReport = @{
 # Configuration
 # ============================================================================
 
-$RepoUrlSsh = "git@github.com:NousResearch/hermes-agent.git"
-$RepoUrlHttps = "https://github.com/NousResearch/hermes-agent.git"
+$distributionRepository = $null
+$distributionMetadataPath = Join-Path (Split-Path -Parent $PSScriptRoot) "downstream\distribution.json"
+$distributionMetadataUri = "https://raw.githubusercontent.com/zapabob/hermes-agent-windows/main/downstream/distribution.json"
+if (Test-Path -LiteralPath $distributionMetadataPath) {
+    try {
+        $distributionMetadata = Get-Content -LiteralPath $distributionMetadataPath -Raw | ConvertFrom-Json
+        $distributionRepository = $distributionMetadata.repository
+    } catch {
+        throw "Invalid distribution metadata at ${distributionMetadataPath}: $_"
+    }
+}
+if (-not $distributionRepository -and (
+    -not $RepositoryUrlHttps -or
+    -not $RepositoryUrlSsh -or
+    -not $RepositoryArchiveBase
+)) {
+    try {
+        $distributionMetadata = Invoke-RestMethod -Uri $distributionMetadataUri -TimeoutSec 30
+        if ($distributionMetadata.id -ne "hermes-agent-windows") {
+            throw "unexpected distribution id"
+        }
+        $distributionRepository = $distributionMetadata.repository
+    } catch {
+        throw "Downstream distribution metadata is unavailable: $_"
+    }
+}
+
+$RepoUrlSsh = if ($RepositoryUrlSsh) {
+    $RepositoryUrlSsh
+} elseif ($distributionRepository) {
+    $distributionRepository.ssh
+} else {
+    throw "Downstream SSH repository authority is unavailable"
+}
+$RepoUrlHttps = if ($RepositoryUrlHttps) {
+    $RepositoryUrlHttps
+} elseif ($distributionRepository) {
+    $distributionRepository.https
+} else {
+    throw "Downstream HTTPS repository authority is unavailable"
+}
+$RepoArchiveBase = if ($RepositoryArchiveBase) {
+    $RepositoryArchiveBase.TrimEnd('/')
+} elseif ($distributionRepository) {
+    $distributionRepository.archive_base.TrimEnd('/')
+} else {
+    throw "Downstream archive authority is unavailable"
+}
+$script:ResolvedPathReport.repository_https = $RepoUrlHttps
+$script:ResolvedPathReport.repository_archive_base = $RepoArchiveBase
 $PythonVersion = "3.11"
 # Minor versions the installer accepts when the requested $PythonVersion isn't
 # available, in preference order.  uv discovers both uv-managed and system
@@ -2281,13 +2332,13 @@ function Install-Repository {
                 # for.  GitHub supports archive URLs for commits, tags, and
                 # branches; we honour Commit > Tag > Branch.
                 if ($Commit) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/$Commit.zip"
+                    $zipUrl = "$RepoArchiveBase/$Commit.zip"
                     $zipLabel = $Commit
                 } elseif ($Tag) {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/tags/$Tag.zip"
+                    $zipUrl = "$RepoArchiveBase/refs/tags/$Tag.zip"
                     $zipLabel = $Tag
                 } else {
-                    $zipUrl = "https://github.com/NousResearch/hermes-agent/archive/refs/heads/$Branch.zip"
+                    $zipUrl = "$RepoArchiveBase/refs/heads/$Branch.zip"
                     $zipLabel = $Branch
                 }
                 $zipPath = "$env:TEMP\hermes-agent-$zipLabel.zip"
@@ -4893,7 +4944,7 @@ try {
     Write-Err "Installation failed: $_"
     Write-Host ""
     Write-Info "If the error is unclear, try downloading and running the script directly:"
-    Write-Host "  Invoke-WebRequest -Uri 'https://hermes-agent.nousresearch.com/install.ps1' -OutFile install.ps1" -ForegroundColor Yellow
+    Write-Host "  Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/zapabob/hermes-agent-windows/main/scripts/install.ps1' -OutFile install.ps1" -ForegroundColor Yellow
     Write-Host "  .\install.ps1" -ForegroundColor Yellow
     Write-Host ""
 }

--- a/scripts/sandbox/pick-release-tags.sh
+++ b/scripts/sandbox/pick-release-tags.sh
@@ -24,9 +24,6 @@
 # checkout has no tags and this exits non-zero rather than silently emitting an
 # empty matrix.
 #
-# Only vYYYY.M.D[.N] release tags are considered; the repo also carries
-# backup/* and one-off tags that are not releases.
-
 set -euo pipefail
 
 COUNT=5
@@ -68,7 +65,7 @@ fi
 # lexicographic sort gets wrong.
 mapfile -t tags < <(
   git -C "$REPO" tag --list 'v*' \
-    | grep -E '^v[0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?$' \
+    | grep -E '^v([0-9]{4}\.[0-9]+\.[0-9]+(\.[0-9]+)?|[0-9]+\.[0-9]+\.[0-9]+-win\.[0-9]+)$' \
     | sort -V
 )
 

--- a/scripts/windows/Get-HermesWorkstationQualification.ps1
+++ b/scripts/windows/Get-HermesWorkstationQualification.ps1
@@ -1,0 +1,192 @@
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\.." )).Path,
+    [string]$OutputPath = (Join-Path $PWD "workstation-qualification.json"),
+    [string]$ArtifactPath = "",
+    [string]$BackendEndpoint = "http://127.0.0.1:9119/api/status",
+    [string]$WatchdogEndpoint = "http://127.0.0.1:9920/health",
+    [string]$LlamaEndpoint = "http://127.0.0.1:8080/v1/models",
+    [string]$EmbeddingEndpoint = "http://127.0.0.1:8082/health",
+    [ValidateSet("passed", "failed", "not_run")]
+    [string]$SleepResumeResult = "not_run",
+    [ValidateSet("passed", "failed", "not_run")]
+    [string]$RestartRecoveryResult = "not_run",
+    [switch]$AllowIncomplete
+)
+
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path -LiteralPath $RepoRoot).Path
+$distribution = Get-Content -LiteralPath (Join-Path $root "downstream\distribution.json") -Raw |
+    ConvertFrom-Json
+
+function Test-LocalEndpoint {
+    param([string]$Uri)
+    try {
+        $response = Invoke-WebRequest -Uri $Uri -UseBasicParsing -TimeoutSec 5
+        return [ordered]@{
+            status = if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300) {
+                "passed"
+            } else {
+                "failed"
+            }
+            http_status = [int]$response.StatusCode
+        }
+    } catch {
+        return [ordered]@{
+            status = "failed"
+            error_type = $_.Exception.GetType().Name
+        }
+    }
+}
+
+$operatingSystem = Get-CimInstance Win32_OperatingSystem
+$nvidiaGpu = $null
+$nvidiaSmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+if ($nvidiaSmi) {
+    $gpuRows = @(& $nvidiaSmi.Source `
+        --query-gpu=name,memory.total `
+        --format=csv,noheader,nounits 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $gpuRows.Count -gt 0) {
+        $parts = $gpuRows[0] -split ",", 2
+        if ($parts.Count -eq 2) {
+            $nvidiaGpu = [ordered]@{
+                model = $parts[0].Trim()
+                vram_mib = [int]$parts[1].Trim()
+                source = "nvidia-smi"
+            }
+        }
+    }
+}
+if (-not $nvidiaGpu) {
+    $videoController = Get-CimInstance Win32_VideoController |
+        Where-Object { $_.Name -match "NVIDIA" } |
+        Select-Object -First 1
+    if ($videoController) {
+        $nvidiaGpu = [ordered]@{
+            model = [string]$videoController.Name
+            vram_mib = [int]([double]$videoController.AdapterRAM / 1MB)
+            source = "Win32_VideoController"
+        }
+    }
+}
+
+$desktopProcesses = @(Get-CimInstance Win32_Process -Filter "Name = 'Hermes.exe'" -ErrorAction SilentlyContinue)
+$desktopIdentities = @()
+foreach ($desktopProcess in $desktopProcesses) {
+    if (-not $desktopProcess.ExecutablePath -or -not (Test-Path -LiteralPath $desktopProcess.ExecutablePath)) {
+        continue
+    }
+    $desktopVersion = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($desktopProcess.ExecutablePath)
+    $desktopIdentities += [ordered]@{
+        product_name = $desktopVersion.ProductName
+        distribution_id = $desktopVersion.InternalName
+        distribution_version = $desktopVersion.SpecialBuild
+        expected_distribution = (
+            $desktopVersion.ProductName -eq $distribution.display_name -and
+            $desktopVersion.InternalName -eq $distribution.id -and
+            $desktopVersion.SpecialBuild -eq $distribution.version
+        )
+    }
+}
+$matchingDesktopCount = @($desktopIdentities | Where-Object { $_.expected_distribution }).Count
+$runtime = [ordered]@{
+    desktop_launch = [ordered]@{
+        status = if ($matchingDesktopCount -gt 0) { "passed" } else { "failed" }
+        process_count = $desktopProcesses.Count
+        matching_distribution_process_count = $matchingDesktopCount
+        identities = $desktopIdentities
+    }
+    backend_launch = Test-LocalEndpoint $BackendEndpoint
+    watchdog_state = Test-LocalEndpoint $WatchdogEndpoint
+    llama_endpoint_state = Test-LocalEndpoint $LlamaEndpoint
+    embedding_endpoint_state = Test-LocalEndpoint $EmbeddingEndpoint
+    sleep_resume_result = $SleepResumeResult
+    restart_recovery_result = $RestartRecoveryResult
+}
+
+$artifact = $null
+if ($ArtifactPath) {
+    $resolvedArtifact = (Resolve-Path -LiteralPath $ArtifactPath).Path
+    $versionInfo = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($resolvedArtifact)
+    $signature = Get-AuthenticodeSignature -LiteralPath $resolvedArtifact
+    $artifact = [ordered]@{
+        file_name = [System.IO.Path]::GetFileName($resolvedArtifact)
+        sha256 = (Get-FileHash -LiteralPath $resolvedArtifact -Algorithm SHA256).Hash.ToLowerInvariant()
+        product_name = $versionInfo.ProductName
+        product_version = $versionInfo.ProductVersion
+        file_version = $versionInfo.FileVersion
+        signature_status = [string]$signature.Status
+        expected_distribution_filename = (
+            [System.IO.Path]::GetFileName($resolvedArtifact).IndexOf(
+                [string]$distribution.version,
+                [System.StringComparison]::OrdinalIgnoreCase
+            ) -ge 0
+        )
+    }
+}
+
+$downstreamSha = (& git -C $root rev-parse HEAD).Trim()
+if ($LASTEXITCODE -ne 0) {
+    throw "Could not resolve downstream commit"
+}
+$requiredRuntimeResults = @(
+    $runtime.desktop_launch.status,
+    $runtime.backend_launch.status,
+    $runtime.watchdog_state.status,
+    $runtime.llama_endpoint_state.status,
+    $runtime.embedding_endpoint_state.status,
+    $runtime.sleep_resume_result,
+    $runtime.restart_recovery_result
+)
+$hardwareQualified = (
+    [Environment]::Is64BitOperatingSystem -and
+    $null -ne $nvidiaGpu -and
+    $nvidiaGpu.vram_mib -gt 0
+)
+$artifactQualified = (
+    $null -ne $artifact -and
+    $artifact.expected_distribution_filename
+)
+$status = if (
+    $hardwareQualified -and
+    $artifactQualified -and
+    @($requiredRuntimeResults | Where-Object { $_ -ne "passed" }).Count -eq 0
+) { "passed" } else { "failed" }
+
+$report = [ordered]@{
+    schema_version = 1
+    status = $status
+    generated_at_utc = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    platform = [ordered]@{
+        windows_caption = [string]$operatingSystem.Caption
+        windows_version = [string]$operatingSystem.Version
+        windows_build = [string]$operatingSystem.BuildNumber
+        cpu_architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+        operating_system_64_bit = [Environment]::Is64BitOperatingSystem
+        nvidia_gpu = $nvidiaGpu
+    }
+    downstream_commit_sha = $downstreamSha
+    upstream_snapshot_sha = [string]$distribution.upstream.snapshot_sha
+    artifact_identity = $artifact
+    runtime = $runtime
+    privacy = [ordered]@{
+        usernames_recorded = $false
+        local_paths_recorded = $false
+        secrets_recorded = $false
+        prompts_or_sessions_recorded = $false
+    }
+}
+
+$destination = [System.IO.Path]::GetFullPath($OutputPath)
+$destinationDirectory = Split-Path -Parent $destination
+if ($destinationDirectory) {
+    New-Item -ItemType Directory -Path $destinationDirectory -Force | Out-Null
+}
+[System.IO.File]::WriteAllText(
+    $destination,
+    (($report | ConvertTo-Json -Depth 8) + [Environment]::NewLine),
+    [System.Text.UTF8Encoding]::new($false)
+)
+$report | ConvertTo-Json -Depth 8
+if ($status -ne "passed" -and -not $AllowIncomplete) {
+    throw "Real workstation qualification failed or remains incomplete"
+}

--- a/scripts/windows/HermesArtifactE2E.ps1
+++ b/scripts/windows/HermesArtifactE2E.ps1
@@ -1,0 +1,152 @@
+function Get-HermesArtifactIdentity {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DesktopPath,
+        [Parameter(Mandatory = $true)]
+        [string]$MetadataPath
+    )
+
+    $metadata = Get-Content -LiteralPath $MetadataPath -Raw | ConvertFrom-Json
+    $version = (Get-Item -LiteralPath $DesktopPath).VersionInfo
+    if ($version.ProductName -ne $metadata.display_name) {
+        throw "Unexpected product name: $($version.ProductName)"
+    }
+    if ($version.InternalName -ne $metadata.id) {
+        throw "Unexpected distribution id: $($version.InternalName)"
+    }
+    if ($version.SpecialBuild -ne $metadata.version) {
+        throw "Unexpected distribution version: $($version.SpecialBuild)"
+    }
+    [ordered]@{
+        product_name = $version.ProductName
+        distribution_id = $version.InternalName
+        distribution_version = $version.SpecialBuild
+        windows_file_version = $version.FileVersion
+    }
+}
+
+function Stop-HermesArtifactProcesses {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$RootPath
+    )
+
+    $root = [System.IO.Path]::GetFullPath($RootPath).TrimEnd('\') + '\'
+    $owned = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.ExecutablePath -and $_.ExecutablePath.StartsWith($root, [System.StringComparison]::OrdinalIgnoreCase)
+    })
+    if ($owned.Count -gt 0) {
+        Stop-Process -Id @($owned.ProcessId) -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Seconds 2
+    }
+}
+
+function Remove-SafeQualificationDirectory {
+    param([string]$Path)
+
+    $resolved = [System.IO.Path]::GetFullPath($Path).TrimEnd('\')
+    $tempRoot = [System.IO.Path]::GetFullPath(
+        [System.IO.Path]::GetTempPath()
+    ).TrimEnd('\')
+    $prefix = $tempRoot + '\'
+    if (-not $resolved.StartsWith($prefix, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove path outside the temporary directory: $resolved"
+    }
+    $parent = [System.IO.Path]::GetDirectoryName($resolved)
+    if (-not $parent.Equals($tempRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Refusing to remove a nested qualification directory: $resolved"
+    }
+    $leaf = [System.IO.Path]::GetFileName($resolved)
+    if ($leaf -notmatch '^Hermes (Installer|Portable|Upgrade) E2E [0-9a-f-]+$') {
+        throw "Refusing to remove an unexpected qualification directory: $resolved"
+    }
+    if (Test-Path -LiteralPath $resolved) {
+        foreach ($attempt in 1..30) {
+            try {
+                Remove-Item -LiteralPath $resolved -Recurse -Force
+                break
+            } catch {
+                if ($attempt -eq 30) { throw }
+                Start-Sleep -Seconds 1
+            }
+        }
+    }
+}
+
+function Invoke-HermesDesktopSmoke {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$DesktopPath,
+        [Parameter(Mandatory = $true)]
+        [string]$ProfileRoot
+    )
+
+    $desktop = (Resolve-Path -LiteralPath $DesktopPath).Path
+    $workingDirectory = Split-Path -Parent $desktop
+    $electronProfile = Join-Path $ProfileRoot "Electron Profile"
+    New-Item -ItemType Directory -Path $electronProfile -Force | Out-Null
+    $process = Start-Process -FilePath $desktop -ArgumentList @("--user-data-dir=$electronProfile") `
+        -WorkingDirectory $workingDirectory -PassThru -WindowStyle Hidden
+    try {
+        Start-Sleep -Seconds 8
+        $owned = @(Get-CimInstance Win32_Process -Filter "Name = 'Hermes.exe'" -ErrorAction Stop |
+            Where-Object { $_.ExecutablePath -eq $desktop })
+        if ($owned.Count -eq 0) {
+            $exit = if ($process.HasExited) { $process.ExitCode } else { "unknown" }
+            throw "Hermes desktop did not remain running during smoke test; exit=$exit"
+        }
+        [ordered]@{
+            started_process_id = $process.Id
+            observed_process_count = $owned.Count
+            observation_seconds = 8
+        }
+    } finally {
+        Stop-HermesArtifactProcesses -RootPath $workingDirectory
+    }
+}
+
+function Invoke-HermesNativeProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+        [string[]]$ArgumentList = @()
+    )
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $FilePath
+    $startInfo.UseShellExecute = $false
+    $startInfo.CreateNoWindow = $true
+    $startInfo.Arguments = (@($ArgumentList | ForEach-Object {
+        if ($_ -match '[\s"]') {
+            '"' + $_.Replace('"', '\"') + '"'
+        } else {
+            $_
+        }
+    }) -join ' ')
+    $process = [System.Diagnostics.Process]::Start($startInfo)
+    $process.WaitForExit()
+    $process.ExitCode
+}
+
+function Write-HermesE2EReport {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Report,
+        [string]$OutputPath = ""
+    )
+
+    $json = ($Report | ConvertTo-Json -Depth 6)
+    if ($OutputPath) {
+        $fullPath = [System.IO.Path]::GetFullPath($OutputPath)
+        $parent = Split-Path -Parent $fullPath
+        if ($parent) {
+            New-Item -ItemType Directory -Path $parent -Force | Out-Null
+        }
+        [System.IO.File]::WriteAllText(
+            $fullPath,
+            ($json + [Environment]::NewLine),
+            [System.Text.UTF8Encoding]::new($false)
+        )
+    }
+    $json
+}

--- a/scripts/windows/Test-HermesInstallerE2E.ps1
+++ b/scripts/windows/Test-HermesInstallerE2E.ps1
@@ -1,0 +1,54 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InstallerPath,
+    [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "HermesArtifactE2E.ps1")
+
+$installer = (Resolve-Path -LiteralPath $InstallerPath).Path
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "Hermes Installer E2E $([guid]::NewGuid())"
+$installRoot = Join-Path $testRoot "Installed Product"
+$profileRoot = Join-Path $testRoot "Profile With Spaces"
+$previousHome = $env:HERMES_HOME
+
+try {
+    New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+    $env:HERMES_HOME = $profileRoot
+    $installExitCode = Invoke-HermesNativeProcess -FilePath $installer -ArgumentList @("/S", "/D=$installRoot")
+    if ($installExitCode -ne 0) {
+        throw "NSIS installer failed with exit code $installExitCode"
+    }
+    $desktop = Get-ChildItem -LiteralPath $installRoot -Filter "Hermes.exe" -File -Recurse |
+        Select-Object -First 1
+    if (-not $desktop) {
+        throw "Installed product does not contain Hermes.exe"
+    }
+    $metadataPath = Join-Path $desktop.Directory.FullName "resources\distribution\distribution.json"
+    if (-not (Test-Path -LiteralPath $metadataPath)) {
+        throw "Installed product is missing distribution metadata"
+    }
+    $identity = Get-HermesArtifactIdentity -DesktopPath $desktop.FullName -MetadataPath $metadataPath
+    $smoke = Invoke-HermesDesktopSmoke -DesktopPath $desktop.FullName -ProfileRoot $profileRoot
+    $report = [ordered]@{
+        schema_version = 1
+        status = "passed"
+        artifact = [System.IO.Path]::GetFileName($installer)
+        non_admin_install = $true
+        path_with_spaces = $true
+        identity = $identity
+        desktop_smoke = $smoke
+    }
+    Write-HermesE2EReport -Report $report -OutputPath $OutputPath
+} finally {
+    $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter "Uninstall*.exe" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($uninstaller) {
+        Invoke-HermesNativeProcess -FilePath $uninstaller.FullName -ArgumentList @("/S") | Out-Null
+    }
+    Stop-HermesArtifactProcesses -RootPath $installRoot
+    $env:HERMES_HOME = $previousHome
+    Remove-SafeQualificationDirectory -Path $testRoot
+}

--- a/scripts/windows/Test-HermesPortableE2E.ps1
+++ b/scripts/windows/Test-HermesPortableE2E.ps1
@@ -1,0 +1,49 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PortableArchive,
+    [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "HermesArtifactE2E.ps1")
+
+$archive = (Resolve-Path -LiteralPath $PortableArchive).Path
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "Hermes Portable E2E $([guid]::NewGuid())"
+$extractRoot = Join-Path $testRoot "Extracted Product"
+$profileRoot = Join-Path $testRoot "Profile With Spaces"
+$previousHome = $env:HERMES_HOME
+
+try {
+    New-Item -ItemType Directory -Path $extractRoot -Force | Out-Null
+    New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+    Expand-Archive -LiteralPath $archive -DestinationPath $extractRoot -Force
+    $desktop = Get-ChildItem -LiteralPath $extractRoot -Filter "Hermes.exe" -File -Recurse |
+        Select-Object -First 1
+    if (-not $desktop) {
+        throw "Portable archive does not contain Hermes.exe"
+    }
+    $resourceRoot = Join-Path $desktop.Directory.FullName "resources"
+    if (-not (Test-Path -LiteralPath (Join-Path $resourceRoot "app.asar"))) {
+        throw "Portable archive is missing resources\app.asar"
+    }
+    $metadataPath = Join-Path $resourceRoot "distribution\distribution.json"
+    if (-not (Test-Path -LiteralPath $metadataPath)) {
+        throw "Portable archive is missing distribution metadata"
+    }
+    $identity = Get-HermesArtifactIdentity -DesktopPath $desktop.FullName -MetadataPath $metadataPath
+    $env:HERMES_HOME = $profileRoot
+    $smoke = Invoke-HermesDesktopSmoke -DesktopPath $desktop.FullName -ProfileRoot $profileRoot
+    $report = [ordered]@{
+        schema_version = 1
+        status = "passed"
+        artifact = [System.IO.Path]::GetFileName($archive)
+        path_with_spaces = $true
+        identity = $identity
+        desktop_smoke = $smoke
+        developer_checkout_required = $false
+    }
+    Write-HermesE2EReport -Report $report -OutputPath $OutputPath
+} finally {
+    $env:HERMES_HOME = $previousHome
+    Remove-SafeQualificationDirectory -Path $testRoot
+}

--- a/scripts/windows/Test-HermesUpgradeE2E.ps1
+++ b/scripts/windows/Test-HermesUpgradeE2E.ps1
@@ -1,0 +1,65 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$PreviousInstaller,
+    [Parameter(Mandatory = $true)]
+    [string]$CurrentInstaller,
+    [string]$OutputPath = ""
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "HermesArtifactE2E.ps1")
+
+$previous = (Resolve-Path -LiteralPath $PreviousInstaller).Path
+$current = (Resolve-Path -LiteralPath $CurrentInstaller).Path
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "Hermes Upgrade E2E $([guid]::NewGuid())"
+$installRoot = Join-Path $testRoot "Installed Product"
+$profileRoot = Join-Path $testRoot "Persistent Profile"
+$sentinel = Join-Path $profileRoot "upgrade-user-data-sentinel.txt"
+$previousHome = $env:HERMES_HOME
+
+try {
+    New-Item -ItemType Directory -Path $profileRoot -Force | Out-Null
+    $env:HERMES_HOME = $profileRoot
+    $firstExitCode = Invoke-HermesNativeProcess -FilePath $previous -ArgumentList @("/S", "/D=$installRoot")
+    if ($firstExitCode -ne 0) {
+        throw "Previous installer failed with exit code $firstExitCode"
+    }
+    [System.IO.File]::WriteAllText($sentinel, "preserve", [System.Text.UTF8Encoding]::new($false))
+    $secondExitCode = Invoke-HermesNativeProcess -FilePath $current -ArgumentList @("/S")
+    if ($secondExitCode -ne 0) {
+        throw "Current installer failed with exit code $secondExitCode"
+    }
+    if (-not (Test-Path -LiteralPath $sentinel)) {
+        throw "Upgrade removed profile data"
+    }
+    $desktop = Get-ChildItem -LiteralPath $installRoot -Filter "Hermes.exe" -File -Recurse |
+        Select-Object -First 1
+    if (-not $desktop) {
+        throw "Upgraded product does not contain Hermes.exe"
+    }
+    $metadataPath = Join-Path $desktop.Directory.FullName "resources\distribution\distribution.json"
+    if (-not (Test-Path -LiteralPath $metadataPath)) {
+        throw "Upgraded product is missing distribution metadata"
+    }
+    $identity = Get-HermesArtifactIdentity -DesktopPath $desktop.FullName -MetadataPath $metadataPath
+    $smoke = Invoke-HermesDesktopSmoke -DesktopPath $desktop.FullName -ProfileRoot $profileRoot
+    $report = [ordered]@{
+        schema_version = 1
+        status = "passed"
+        previous_artifact = [System.IO.Path]::GetFileName($previous)
+        current_artifact = [System.IO.Path]::GetFileName($current)
+        profile_data_preserved = $true
+        identity = $identity
+        desktop_smoke = $smoke
+    }
+    Write-HermesE2EReport -Report $report -OutputPath $OutputPath
+} finally {
+    $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter "Uninstall*.exe" -File -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($uninstaller) {
+        Invoke-HermesNativeProcess -FilePath $uninstaller.FullName -ArgumentList @("/S") | Out-Null
+    }
+    Stop-HermesArtifactProcesses -RootPath $installRoot
+    $env:HERMES_HOME = $previousHome
+    Remove-SafeQualificationDirectory -Path $testRoot
+}

--- a/scripts/windows/Test-HermesWindowsQualification.ps1
+++ b/scripts/windows/Test-HermesWindowsQualification.ps1
@@ -1,0 +1,321 @@
+param(
+    [string]$RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\.." )).Path,
+    [string]$OutputDirectory = (Join-Path $PWD "windows-qualification"),
+    [string]$InstallerPath = "",
+    [string]$PortablePath = "",
+    [string]$PreviousInstallerPath = "",
+    [string]$WorkstationEvidencePath = "",
+    [ValidateSet("ci", "real_workstation")]
+    [string]$Scope = "ci"
+)
+
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path -LiteralPath $RepoRoot).Path
+$output = [System.IO.Path]::GetFullPath($OutputDirectory)
+New-Item -ItemType Directory -Path $output -Force | Out-Null
+$python = Join-Path $root ".venv\Scripts\python.exe"
+if (-not (Test-Path -LiteralPath $python)) {
+    $sharedVenvPython = [System.IO.Path]::GetFullPath(
+        (Join-Path $root "..\..\.venv\Scripts\python.exe")
+    )
+    if (Test-Path -LiteralPath $sharedVenvPython) {
+        $python = $sharedVenvPython
+    } else {
+        $python = (Get-Command python -ErrorAction Stop).Source
+    }
+}
+$gates = [ordered]@{}
+$details = [ordered]@{}
+
+function Invoke-NativeChecked {
+    param([string]$FilePath, [string[]]$ArgumentList, [string]$WorkingDirectory = $root)
+    Push-Location $WorkingDirectory
+    try {
+        & $FilePath @ArgumentList
+        if ($LASTEXITCODE -ne 0) {
+            throw "$FilePath failed with exit code $LASTEXITCODE"
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-QualificationGate {
+    param([string]$Name, [scriptblock]$Action)
+    $started = [DateTime]::UtcNow
+    try {
+        & $Action
+        $gates[$Name] = "passed"
+        $details[$Name] = [ordered]@{
+            status = "passed"
+            duration_ms = [int]([DateTime]::UtcNow - $started).TotalMilliseconds
+        }
+    } catch {
+        Write-Error -ErrorAction Continue "Qualification gate ${Name} failed: $_"
+        $gates[$Name] = "failed"
+        $details[$Name] = [ordered]@{
+            status = "failed"
+            duration_ms = [int]([DateTime]::UtcNow - $started).TotalMilliseconds
+            error_type = $_.Exception.GetType().Name
+        }
+    }
+}
+
+$previousHermesHome = [Environment]::GetEnvironmentVariable("HERMES_HOME", "Process")
+$temporaryRoot = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath()).TrimEnd('\')
+$qualificationHome = Join-Path $temporaryRoot "Hermes Qualification Home $([guid]::NewGuid())"
+New-Item -ItemType Directory -Path $qualificationHome -Force | Out-Null
+[Environment]::SetEnvironmentVariable("HERMES_HOME", $qualificationHome, "Process")
+
+try {
+Invoke-QualificationGate "windows_native_paths" {
+    Invoke-NativeChecked $python @("-m", "pytest", "tests/downstream/test_windows_contracts.py", "-q")
+}
+Invoke-QualificationGate "cli_start" {
+    Invoke-NativeChecked $python @("-m", "hermes_cli.main", "--version")
+}
+Invoke-QualificationGate "local_provider_contract" {
+    $llamaEnvironmentNames = @(
+        "HERMES_LLAMA_SERVER_EXE",
+        "HERMES_LLAMA_MODEL_PATH",
+        "HERMES_LLAMA_FALLBACK_AUTOSTART",
+        "HERMES_LLAMA_GPU_PROFILE",
+        "HERMES_LLAMA_KV_PROFILE",
+        "HERMES_LLAMA_SPEC_TYPE",
+        "HERMES_LLAMA_HOST",
+        "HERMES_LLAMA_PORT",
+        "HERMES_LLAMA_CONTEXT_SIZE",
+        "HERMES_LLAMA_WAIT_SECONDS",
+        "HERMES_LLAMA_SPEC_DRAFT_N_MAX",
+        "HERMES_LLAMA_SPEC_DRAFT_P_MIN"
+    )
+    $savedLlamaEnvironment = @{}
+    foreach ($name in $llamaEnvironmentNames) {
+        $savedLlamaEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, "Process")
+        [Environment]::SetEnvironmentVariable($name, $null, "Process")
+    }
+    try {
+        Invoke-NativeChecked $python @(
+            "-m", "pytest", "tests/hermes_cli/test_llama_fallback_runtime.py", "-q"
+        )
+    } finally {
+        foreach ($name in $llamaEnvironmentNames) {
+            [Environment]::SetEnvironmentVariable(
+                $name,
+                $savedLlamaEnvironment[$name],
+                "Process"
+            )
+        }
+    }
+}
+Invoke-QualificationGate "upstream_api_compat" {
+    Invoke-NativeChecked $python @(
+        "-m", "pytest", "tests/downstream/test_upstream_api_contracts.py", "-q"
+    )
+}
+Invoke-QualificationGate "windows_regression" {
+    Invoke-NativeChecked $python @(
+        "-m", "pytest",
+        "tests/downstream/test_windows_contracts.py",
+        "tests/downstream/test_ci_contracts.py",
+        "tests/downstream/test_repository_identity.py",
+        "-q"
+    )
+}
+Invoke-QualificationGate "updater_contract" {
+    Invoke-NativeChecked $python @(
+        "-m", "pytest",
+        "tests/hermes_cli/test_downstream_update_authority.py",
+        "tests/hermes_cli/test_update_zip_fallback_guards.py",
+        "-q"
+    )
+}
+Invoke-QualificationGate "session_persistence" {
+    Invoke-NativeChecked $python @("-m", "pytest", "tests/hermes_state/test_reasoning_roundtrip.py", "-q")
+}
+Invoke-QualificationGate "release_metadata" {
+    Invoke-NativeChecked $python @(
+        "-m", "pytest",
+        "tests/downstream/test_distribution_metadata.py",
+        "tests/downstream/test_windows_release_manifest.py",
+        "-q"
+    )
+}
+Invoke-QualificationGate "security" {
+    Invoke-NativeChecked $python @(
+        "-m", "pytest",
+        "tests/hermes_cli/test_update_zip_symlink_reject.py",
+        "tests/hermes_cli/test_update_self_lock.py",
+        "-q"
+    )
+}
+Invoke-QualificationGate "install_source" {
+    Invoke-NativeChecked "powershell.exe" @(
+        "-NoProfile", "-ExecutionPolicy", "Bypass", "-File",
+        (Join-Path $root "scripts\install.ps1"), "-ShowResolvedPaths"
+    )
+}
+Invoke-QualificationGate "desktop_build" {
+    Invoke-NativeChecked "npm" @("--workspace", "apps/desktop", "run", "typecheck")
+    Invoke-NativeChecked "npm" @(
+        "--workspace", "apps/desktop", "run", "test:desktop:platforms", "--",
+        "electron/distribution.test.ts", "electron/bootstrap-runner.test.ts"
+    )
+    Invoke-NativeChecked "npm" @("--workspace", "apps/desktop", "run", "build")
+}
+Invoke-QualificationGate "watchdog" {
+    Invoke-NativeChecked "go" @("test", "./...") (Join-Path $root "scripts\windows\watchdog-go")
+}
+
+if ($InstallerPath) {
+    Invoke-QualificationGate "install_e2e" {
+        Invoke-NativeChecked "powershell.exe" @(
+            "-NoProfile", "-ExecutionPolicy", "Bypass", "-File",
+            (Join-Path $root "scripts\windows\Test-HermesInstallerE2E.ps1"),
+            "-InstallerPath", $InstallerPath,
+            "-OutputPath", (Join-Path $output "installer-e2e.json")
+        )
+    }
+} else {
+    $gates["install_e2e"] = "not_run"
+    $details["install_e2e"] = [ordered]@{ status = "not_run" }
+}
+
+if ($PortablePath) {
+    Invoke-QualificationGate "portable_e2e" {
+        Invoke-NativeChecked "powershell.exe" @(
+            "-NoProfile", "-ExecutionPolicy", "Bypass", "-File",
+            (Join-Path $root "scripts\windows\Test-HermesPortableE2E.ps1"),
+            "-PortableArchive", $PortablePath,
+            "-OutputPath", (Join-Path $output "portable-e2e.json")
+        )
+    }
+} else {
+    $gates["portable_e2e"] = "not_run"
+    $details["portable_e2e"] = [ordered]@{ status = "not_run" }
+}
+
+if ($PreviousInstallerPath -and $InstallerPath) {
+    Invoke-QualificationGate "upgrade_e2e" {
+        Invoke-NativeChecked "powershell.exe" @(
+            "-NoProfile", "-ExecutionPolicy", "Bypass", "-File",
+            (Join-Path $root "scripts\windows\Test-HermesUpgradeE2E.ps1"),
+            "-PreviousInstaller", $PreviousInstallerPath,
+            "-CurrentInstaller", $InstallerPath,
+            "-OutputPath", (Join-Path $output "upgrade-e2e.json")
+        )
+    }
+} else {
+    $gates["upgrade_e2e"] = "not_run"
+    $details["upgrade_e2e"] = [ordered]@{ status = "not_run" }
+}
+
+$gates["windows_native_python"] = if (
+    $gates.windows_native_paths -eq "passed" -and
+    $gates.cli_start -eq "passed" -and
+    $gates.local_provider_contract -eq "passed" -and
+    $gates.upstream_api_compat -eq "passed" -and
+    $gates.windows_regression -eq "passed" -and
+    $gates.updater_contract -eq "passed" -and
+    $gates.session_persistence -eq "passed"
+) { "passed" } else { "failed" }
+$gates["windows_native_desktop"] = $gates.desktop_build
+$gates["watchdog_go"] = $gates.watchdog
+$gates["security_lock"] = $gates.security
+$gates["security_locks"] = $gates.security
+
+if ($Scope -eq "real_workstation") {
+    if ($WorkstationEvidencePath) {
+        $workstationEvidence = Get-Content -LiteralPath $WorkstationEvidencePath -Raw | ConvertFrom-Json
+        $gates["real_workstation_evidence"] = if ($workstationEvidence.status -eq "passed") {
+            "passed"
+        } else {
+            "failed"
+        }
+        $details["real_workstation_evidence"] = [ordered]@{
+            status = $gates.real_workstation_evidence
+            schema_version = $workstationEvidence.schema_version
+        }
+    } else {
+        $gates["real_workstation_evidence"] = "not_run"
+        $details["real_workstation_evidence"] = [ordered]@{ status = "not_run" }
+    }
+}
+
+$required = @(
+    "install_e2e", "portable_e2e", "upgrade_e2e", "windows_native_python",
+    "windows_native_desktop", "watchdog_go", "upstream_api_compat",
+    "windows_regression", "security_locks"
+)
+if ($Scope -eq "real_workstation") {
+    $required += "real_workstation_evidence"
+}
+$status = if (@($required | Where-Object { $gates[$_] -ne "passed" }).Count -eq 0) {
+    "passed"
+} else {
+    "failed"
+}
+$downstreamSha = (& git -C $root rev-parse HEAD).Trim()
+$distribution = Get-Content -LiteralPath (Join-Path $root "downstream\distribution.json") -Raw | ConvertFrom-Json
+$executedInCi = ($env:GITHUB_ACTIONS -eq "true")
+$report = [ordered]@{
+    schema_version = 1
+    status = $status
+    scope = $Scope
+    generated_at_utc = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    downstream_commit_sha = $downstreamSha
+    upstream_snapshot_sha = $distribution.upstream.snapshot_sha
+    executed_in_ci = $executedInCi
+    ci_qualified = ($executedInCi -and $Scope -eq "ci" -and $status -eq "passed")
+    real_workstation_qualified = (
+        $Scope -eq "real_workstation" -and
+        $status -eq "passed" -and
+        $gates.real_workstation_evidence -eq "passed"
+    )
+    gates = $gates
+    details = $details
+}
+
+$jsonPath = Join-Path $output "windows-qualification.json"
+$summaryPath = Join-Path $output "windows-qualification.md"
+[System.IO.File]::WriteAllText(
+    $jsonPath,
+    (($report | ConvertTo-Json -Depth 8) + [Environment]::NewLine),
+    [System.Text.UTF8Encoding]::new($false)
+)
+$summary = @(
+    "# Windows qualification",
+    "",
+    "Status: $status",
+    "Scope: $Scope",
+    "Downstream commit: $downstreamSha",
+    "Frozen upstream snapshot: $($distribution.upstream.snapshot_sha)",
+    "",
+    "| Gate | Result |",
+    "| --- | --- |"
+)
+foreach ($name in $gates.Keys) {
+    $summary += "| $name | $($gates[$name]) |"
+}
+[System.IO.File]::WriteAllText(
+    $summaryPath,
+    (($summary -join [Environment]::NewLine) + [Environment]::NewLine),
+    [System.Text.UTF8Encoding]::new($false)
+)
+$report | ConvertTo-Json -Depth 8
+if ($status -ne "passed") {
+    throw "Windows qualification failed"
+}
+} finally {
+    [Environment]::SetEnvironmentVariable("HERMES_HOME", $previousHermesHome, "Process")
+    $resolvedQualificationHome = [System.IO.Path]::GetFullPath($qualificationHome).TrimEnd('\')
+    $qualificationParent = [System.IO.Path]::GetDirectoryName($resolvedQualificationHome)
+    $qualificationLeaf = [System.IO.Path]::GetFileName($resolvedQualificationHome)
+    if (
+        $qualificationParent.Equals($temporaryRoot, [System.StringComparison]::OrdinalIgnoreCase) -and
+        $qualificationLeaf -match '^Hermes Qualification Home [0-9a-f-]+$' -and
+        (Test-Path -LiteralPath $resolvedQualificationHome)
+    ) {
+        Remove-Item -LiteralPath $resolvedQualificationHome -Recurse -Force
+    }
+}

--- a/tests/downstream/test_ci_contracts.py
+++ b/tests/downstream/test_ci_contracts.py
@@ -8,6 +8,7 @@ import yaml
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/fork-cicd.yml"
 SCHEDULED = ROOT / ".github/workflows/windows-full-qualification.yml"
+RELEASE = ROOT / ".github/workflows/windows-release.yml"
 
 
 def _workflow(path: Path) -> dict:
@@ -95,7 +96,7 @@ def test_scheduled_full_windows_qualification_exists() -> None:
 
 def test_external_actions_are_commit_pinned() -> None:
     action = re.compile(r"^([^./][^@]*)@([0-9a-f]{40})$")
-    for path in (WORKFLOW, SCHEDULED):
+    for path in (WORKFLOW, SCHEDULED, RELEASE):
         for line in path.read_text(encoding="utf-8").splitlines():
             stripped = line.strip()
             if not stripped.startswith("uses:"):

--- a/tests/downstream/test_distribution_metadata.py
+++ b/tests/downstream/test_distribution_metadata.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tomllib
+
+import pytest
+
+from downstream.distribution import (
+    distribution_version_lines,
+    install_script_url,
+    load_distribution,
+    update_archive_url,
+)
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_distribution_metadata_is_the_downstream_product_authority() -> None:
+    distribution = load_distribution()
+
+    assert distribution.id == "hermes-agent-windows"
+    assert distribution.display_name == "Hermes Agent Windows Workstation Edition"
+    assert distribution.version == "0.20.5-win.1"
+    assert distribution.repository.slug == "zapabob/hermes-agent-windows"
+    assert distribution.upstream.snapshot_sha == (
+        "1fe0f2f3ac9748ce799272eb93bee2937b5ab802"
+    )
+    assert distribution.platform.tier == 1
+    assert distribution.platform.architectures == ("x64",)
+    assert distribution.channels.default == "stable"
+    assert distribution.channels.supported == ("stable", "preview")
+    assert distribution.update.allow_upstream_sync is False
+
+
+def test_distribution_metadata_accessors_are_read_only() -> None:
+    distribution = load_distribution()
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(distribution, "version", "changed")
+
+
+def test_distribution_network_urls_never_target_upstream() -> None:
+    script_url = install_script_url("a" * 40, "install.ps1")
+    archive_url = update_archive_url("main")
+
+    assert script_url == (
+        "https://raw.githubusercontent.com/zapabob/hermes-agent-windows/"
+        f"{'a' * 40}/scripts/install.ps1"
+    )
+    assert archive_url == (
+        "https://github.com/zapabob/hermes-agent-windows/archive/refs/heads/main.zip"
+    )
+    assert "NousResearch" not in script_url
+    assert "NousResearch" not in archive_url
+    assert install_script_url("preview/windows", "install.ps1") == (
+        "https://raw.githubusercontent.com/zapabob/hermes-agent-windows/"
+        "preview/windows/scripts/install.ps1"
+    )
+    assert update_archive_url("preview/windows") == (
+        "https://github.com/zapabob/hermes-agent-windows/"
+        "archive/refs/heads/preview/windows.zip"
+    )
+
+
+def test_version_lines_identify_distribution_snapshot_and_checkout() -> None:
+    lines = distribution_version_lines(downstream_sha="b" * 40)
+
+    assert lines == (
+        "Distribution: Hermes Agent Windows Workstation Edition 0.20.5-win.1",
+        "Frozen upstream: 1fe0f2f3ac97",
+        "Downstream revision: bbbbbbbbbbbb",
+        "Update channel: stable",
+    )
+
+
+def test_distribution_json_is_packaged_with_the_python_distribution() -> None:
+    pyproject_text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    pyproject = tomllib.loads(pyproject_text)
+
+    assert "downstream" in pyproject["tool"]["setuptools"]["packages"]["find"]["include"]
+    assert "downstream.*" in pyproject["tool"]["setuptools"]["packages"]["find"]["include"]
+    assert "distribution.json" in pyproject["tool"]["setuptools"]["package-data"][
+        "downstream"
+    ]
+
+
+def test_standalone_windows_installer_fails_closed_on_downstream_metadata() -> None:
+    installer = (ROOT / "scripts" / "install.ps1").read_text(encoding="utf-8")
+
+    assert (
+        "https://raw.githubusercontent.com/zapabob/hermes-agent-windows/"
+        "main/downstream/distribution.json"
+    ) in installer
+    assert "https://github.com/NousResearch/hermes-agent.git" not in installer
+
+
+def test_desktop_packaging_has_downstream_identity_installer_and_portable_targets() -> (
+    None
+):
+    package = json.loads(
+        (ROOT / "apps" / "desktop" / "package.json").read_text(encoding="utf-8")
+    )
+
+    assert package["productName"] == "Hermes Agent Windows Workstation Edition"
+    assert package["version"] == "0.20.5-win.1"
+    assert package["build"]["appId"] == "io.github.zapabob.hermes-agent-windows"
+    assert package["build"]["executableName"] == "Hermes"
+    assert package["build"]["nsis"]["guid"] == ("48ae4bdc-0f8d-5252-af1e-bf7c0a8c3649")
+    assert "nsis" in package["build"]["win"]["target"]
+    assert "zip" in package["build"]["win"]["target"]
+    assert package["scripts"]["dist:win:portable"].endswith("--win zip")
+
+
+def test_windows_release_workflow_is_pinned_and_downstream_only() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "windows-release.yml").read_text(
+        encoding="utf-8"
+    )
+    install_e2e = (ROOT / ".github" / "workflows" / "install-e2e.yml").read_text(
+        encoding="utf-8"
+    )
+    install_e2e_run = (
+        ROOT / ".github" / "workflows" / "install-e2e-run.yml"
+    ).read_text(encoding="utf-8")
+
+    assert (
+        "actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a"
+        in workflow
+    )
+    assert (
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in workflow
+    )
+    assert "Test-HermesWindowsQualification.ps1" in workflow
+    assert "--attestation-status generated" in workflow
+    assert "gh release create" in workflow
+    assert "Get-ChildItem -LiteralPath $bundle -File -Recurse" in workflow
+    assert "NousResearch/hermes-agent.git" not in install_e2e
+    assert "HERMES_DEV_SANDBOX_UPSTREAM: https://github.com/${{ github.repository }}.git" in (
+        install_e2e_run
+    )
+    assert "8447bf369a0977b0dadf5c78896e194001dd1584" in install_e2e
+
+
+def test_windows_demo_requires_exact_clean_candidate_and_dedicated_ports() -> None:
+    demo = (ROOT / "scripts" / "demo" / "windows-demo.ps1").read_text(
+        encoding="utf-8"
+    )
+
+    assert "DemoRoot already exists; choose a new dedicated directory" in demo
+    assert "$installStamp.commit -ne $downstreamSha" in demo
+    assert "$installStamp.dirty -ne $false" in demo
+    assert "Dedicated demo ports are already in use" in demo
+    assert 'downstream_identity = "failed"' in demo
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="PowerShell installer contract")
+def test_install_ps1_resolves_downstream_repository_from_distribution_json() -> None:
+    result = subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(ROOT / "scripts" / "install.ps1"),
+            "-ShowResolvedPaths",
+        ],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    assert payload["repository_https"] == (
+        "https://github.com/zapabob/hermes-agent-windows.git"
+    )
+    assert payload["repository_archive_base"] == (
+        "https://github.com/zapabob/hermes-agent-windows/archive"
+    )

--- a/tests/downstream/test_readme_contract.py
+++ b/tests/downstream/test_readme_contract.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-README = (Path(__file__).resolve().parents[2] / "README.md").read_text(encoding="utf-8")
+ROOT = Path(__file__).resolve().parents[2]
+README = (ROOT / "README.md").read_text(encoding="utf-8")
 
 
 def test_readme_has_downstream_identity_and_attribution() -> None:
@@ -39,9 +40,13 @@ def test_readme_uses_required_section_order() -> None:
     assert positions == sorted(positions)
 
 
-def test_readme_installs_the_fork_from_source_only() -> None:
+def test_readme_exposes_verified_windows_install_surfaces() -> None:
     assert "git clone https://github.com/zapabob/hermes-agent-windows.git" in README
-    assert "no verified fork-specific binary installer" in README
+    assert "https://github.com/zapabob/hermes-agent-windows/releases" in README
+    assert "installer" in README.lower()
+    assert "portable" in README.lower()
+    assert "0.20.5-win.1" in README
+    assert "docs/windows/INSTALL.md" in README
     assert "curl -fsSL https://raw.githubusercontent.com/NousResearch" not in README
     assert "official upstream installer" in README.lower()
 
@@ -50,3 +55,18 @@ def test_readme_preserves_upstream_identity() -> None:
     assert "https://github.com/NousResearch/hermes-agent" in README
     assert "official Windows edition" not in README
     assert "world's largest" not in README
+
+
+def test_translated_readmes_keep_distribution_metadata_in_parity() -> None:
+    for name in ("README.md", "README.ja.md", "README.zh-CN.md"):
+        content = (ROOT / name).read_text(encoding="utf-8")
+        for value in (
+            "Hermes Agent Windows Workstation Edition",
+            "zapabob/hermes-agent-windows",
+            "NousResearch/hermes-agent",
+            "0.20.5-win.1",
+            "stable",
+            "preview",
+            "docs/windows/INSTALL.md",
+        ):
+            assert value in content, f"{name}: {value}"

--- a/tests/downstream/test_release_notes.py
+++ b/tests/downstream/test_release_notes.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from downstream.release_notes import render_release_notes
+
+
+def test_release_notes_are_truthful_deterministic_and_complete() -> None:
+    manifest = {
+        "product_name": "Hermes Agent Windows Workstation Edition",
+        "downstream_version": "0.20.5-win.1",
+        "downstream_commit_sha": "a" * 40,
+        "upstream_snapshot_sha": "b" * 40,
+        "release_channel": "stable",
+        "installer_signed": False,
+        "attestation_status": "generated",
+        "windows_qualification": {
+            "status": "passed",
+            "real_workstation_qualified": False,
+        },
+        "artifacts": [
+            {"name": "setup.exe", "sha256": "c" * 64},
+            {"name": "portable.zip", "sha256": "d" * 64},
+        ],
+    }
+    notes = render_release_notes(
+        manifest=manifest,
+        features={
+            "features": [
+                {
+                    "id": "windows-native-runtime",
+                    "status": "verified",
+                    "windows_required": True,
+                }
+            ]
+        },
+        carry={"carry": [{"id": "one"}]},
+        adoption={
+            "decision_counts": {"ADOPT": 2},
+            "category_counts": {"SECURITY_CRITICAL": 1},
+        },
+        snapshot={"upstream_head_sha": "b" * 40},
+        commits=[
+            {
+                "sha": "e" * 40,
+                "subject": "fix windows desktop release",
+                "paths": ["apps/desktop/release.ts"],
+            }
+        ],
+        previous_tag=None,
+    )
+
+    for heading in (
+        "Windows Workstation changes",
+        "Upstream snapshot",
+        "Security",
+        "Bug fixes",
+        "Local AI",
+        "Desktop",
+        "Memory",
+        "Voice / VR / Unity",
+        "Known limitations",
+        "Artifact hashes",
+    ):
+        assert f"## {heading}" in notes
+    assert "Installer signature: Unsigned" in notes
+    assert "Physical workstation qualification: not recorded as passed" in notes
+    assert f"Frozen upstream snapshot: `{'b' * 40}`" in notes
+    assert f"`{'c' * 64}`  `setup.exe`" in notes
+    assert "No earlier downstream Windows tag is recorded" in notes
+    assert "latest Hermes" not in notes

--- a/tests/downstream/test_windows_release_manifest.py
+++ b/tests/downstream/test_windows_release_manifest.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import hashlib
+import json
+
+import pytest
+
+from scripts.downstream.generate_release_manifest import generate_release_bundle
+
+
+def _qualification(
+    status: str = "passed", downstream_sha: str = "a" * 40
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "status": status,
+        "downstream_commit_sha": downstream_sha,
+        "ci_qualified": True,
+        "real_workstation_qualified": False,
+        "gates": {
+            "install_e2e": "passed",
+            "portable_e2e": "passed",
+            "upgrade_e2e": "passed",
+            "windows_native_python": "passed",
+            "windows_native_desktop": "passed",
+            "watchdog_go": "passed",
+            "upstream_api_compat": "passed",
+            "windows_regression": "passed",
+            "security_locks": "passed",
+        },
+    }
+
+
+def test_release_bundle_contains_required_identity_hashes_and_truthful_signing(
+    tmp_path,
+) -> None:
+    installer = tmp_path / "Hermes-Setup.exe"
+    portable = tmp_path / "Hermes-portable.zip"
+    installer.write_bytes(b"installer")
+    portable.write_bytes(b"portable")
+    output = tmp_path / "release"
+
+    manifest = generate_release_bundle(
+        installer=installer,
+        portable=portable,
+        qualification=_qualification(),
+        output_dir=output,
+        channel="stable",
+        downstream_sha="a" * 40,
+        installer_signed=False,
+        build_timestamp_utc="2026-08-27T00:00:00Z",
+        attestation_status="generated",
+    )
+
+    assert manifest["product_name"] == "Hermes Agent Windows Workstation Edition"
+    assert manifest["distribution_id"] == "hermes-agent-windows"
+    assert manifest["downstream_version"] == "0.20.5-win.1"
+    assert manifest["downstream_commit_sha"] == "a" * 40
+    assert manifest["upstream_snapshot_sha"] == (
+        "1fe0f2f3ac9748ce799272eb93bee2937b5ab802"
+    )
+    assert manifest["release_channel"] == "stable"
+    assert manifest["architecture"] == "x64"
+    assert manifest["installer_signed"] is False
+    assert manifest["windows_qualification"] == {
+        "status": "passed",
+        "schema_version": 1,
+        "ci_qualified": True,
+        "real_workstation_qualified": False,
+    }
+    artifacts = {item["kind"]: item for item in manifest["artifacts"]}
+    assert artifacts["installer"]["sha256"] == hashlib.sha256(b"installer").hexdigest()
+    assert artifacts["portable"]["sha256"] == hashlib.sha256(b"portable").hexdigest()
+    assert manifest["portable_artifact"] == artifacts["portable"]["name"]
+    assert artifacts["installer"]["signed"] is False
+
+    on_disk = json.loads((output / "release-manifest.json").read_text(encoding="utf-8"))
+    assert on_disk == manifest
+    sums = (output / "SHA256SUMS.txt").read_text(encoding="utf-8")
+    assert artifacts["installer"]["name"] in sums
+    assert artifacts["portable"]["name"] in sums
+    notes = (output / "RELEASE_NOTES.md").read_text(encoding="utf-8")
+    assert "Unsigned" in notes
+    assert str(tmp_path) not in json.dumps(manifest)
+
+
+def test_stable_release_refuses_incomplete_qualification(tmp_path) -> None:
+    installer = tmp_path / "setup.exe"
+    portable = tmp_path / "portable.zip"
+    installer.write_bytes(b"installer")
+    portable.write_bytes(b"portable")
+    qualification = _qualification(status="failed", downstream_sha="b" * 40)
+
+    with pytest.raises(ValueError, match="stable release requires"):
+        generate_release_bundle(
+            installer=installer,
+            portable=portable,
+            qualification=qualification,
+            output_dir=tmp_path / "release",
+            channel="stable",
+            downstream_sha="b" * 40,
+            installer_signed=False,
+            build_timestamp_utc="2026-08-27T00:00:00Z",
+            attestation_status="generated",
+        )
+
+
+def test_stable_release_refuses_non_ci_or_wrong_sha_qualification(tmp_path) -> None:
+    installer = tmp_path / "setup.exe"
+    portable = tmp_path / "portable.zip"
+    installer.write_bytes(b"installer")
+    portable.write_bytes(b"portable")
+    qualification = _qualification(downstream_sha="c" * 40)
+    qualification["ci_qualified"] = False
+
+    with pytest.raises(ValueError, match="exact_downstream_sha, ci_qualified"):
+        generate_release_bundle(
+            installer=installer,
+            portable=portable,
+            qualification=qualification,
+            output_dir=tmp_path / "release",
+            channel="stable",
+            downstream_sha="d" * 40,
+            installer_signed=False,
+            build_timestamp_utc="2026-08-27T00:00:00Z",
+            attestation_status="generated",
+        )

--- a/tests/hermes_cli/test_downstream_update_authority.py
+++ b/tests/hermes_cli/test_downstream_update_authority.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from hermes_cli import main as hermes_main
+from hermes_cli import update_cmd
+
+
+DOWNSTREAM_HTTPS = "https://github.com/zapabob/hermes-agent-windows.git"
+DOWNSTREAM_SSH = "git@github.com:zapabob/hermes-agent-windows.git"
+
+
+def test_downstream_origin_is_a_managed_distribution_not_a_generic_fork() -> None:
+    assert update_cmd._is_fork(DOWNSTREAM_HTTPS) is False
+    assert update_cmd._is_fork(DOWNSTREAM_SSH) is False
+    assert update_cmd._is_fork("https://github.com/example/hermes-agent.git") is True
+
+
+def test_downstream_zip_fallback_uses_distribution_archive() -> None:
+    assert update_cmd._distribution_archive_url("main") == (
+        "https://github.com/zapabob/hermes-agent-windows/archive/refs/heads/main.zip"
+    )
+
+
+def test_downstream_zip_fallback_fails_closed_without_distribution_metadata(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "downstream.distribution.update_archive_url",
+        lambda _branch: (_ for _ in ()).throw(OSError("missing metadata")),
+    )
+
+    with pytest.raises(RuntimeError, match="downstream distribution metadata"):
+        update_cmd._distribution_archive_url("main")
+
+
+def test_downstream_update_check_never_fetches_upstream(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr("hermes_cli.config.detect_install_method", lambda _root: "git")
+    commands: list[list[str]] = []
+
+    def run(command, **_kwargs):
+        commands.append(command)
+        joined = " ".join(command)
+        if "remote get-url origin" in joined:
+            return subprocess.CompletedProcess(command, 0, DOWNSTREAM_HTTPS + "\n", "")
+        if "remote get-url upstream" in joined or "fetch upstream" in joined:
+            raise AssertionError(
+                f"downstream update check consulted upstream: {joined}"
+            )
+        if "rev-parse --is-shallow-repository" in joined:
+            return subprocess.CompletedProcess(command, 0, "false\n", "")
+        if "rev-list" in joined:
+            return subprocess.CompletedProcess(command, 0, "0\n", "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", run)
+    update_cmd._cmd_update_check()
+
+    assert any("fetch origin main" in " ".join(command) for command in commands)
+    assert "Already up to date" in capsys.readouterr().out

--- a/tests/hermes_cli/test_llama_fallback_runtime.py
+++ b/tests/hermes_cli/test_llama_fallback_runtime.py
@@ -12,6 +12,28 @@ from hermes_cli.llama_fallback_runtime import (
 )
 
 
+_LLAMA_ENV_OVERRIDES = (
+    "HERMES_LLAMA_SERVER_EXE",
+    "HERMES_LLAMA_MODEL_PATH",
+    "HERMES_LLAMA_FALLBACK_AUTOSTART",
+    "HERMES_LLAMA_GPU_PROFILE",
+    "HERMES_LLAMA_KV_PROFILE",
+    "HERMES_LLAMA_SPEC_TYPE",
+    "HERMES_LLAMA_HOST",
+    "HERMES_LLAMA_PORT",
+    "HERMES_LLAMA_CONTEXT_SIZE",
+    "HERMES_LLAMA_WAIT_SECONDS",
+    "HERMES_LLAMA_SPEC_DRAFT_N_MAX",
+    "HERMES_LLAMA_SPEC_DRAFT_P_MIN",
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_llama_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in _LLAMA_ENV_OVERRIDES:
+        monkeypatch.delenv(name, raising=False)
+
+
 def test_llama_cpp_configured_from_fallback_providers():
     cfg = {
         "fallback_providers": [

--- a/tests/hermes_cli/test_startup_fast_guards.py
+++ b/tests/hermes_cli/test_startup_fast_guards.py
@@ -50,6 +50,7 @@ def test_startup_fast_import_weight():
         [sys.executable, "-c", probe],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=30,
         cwd=REPO_ROOT,
     )
@@ -69,6 +70,7 @@ def _run_version(env_overrides: dict) -> subprocess.CompletedProcess:
         [sys.executable, "-m", "hermes_cli.main", "--version"],
         capture_output=True,
         text=True,
+        encoding="utf-8",
         timeout=60,
         cwd=REPO_ROOT,
         env=env,
@@ -81,7 +83,16 @@ def test_fast_version_parity_off_termux(tmp_path):
     result = _run_version({"HERMES_HOME": str(home), "TERMUX_VERSION": ""})
     assert result.returncode == 0, result.stderr
     out = result.stdout
-    for field in ("Hermes Agent v", "Install directory:", "Python:", "OpenAI SDK:"):
+    for field in (
+        "Hermes Agent v",
+        "Distribution: Hermes Agent Windows Workstation Edition 0.20.5-win.1",
+        "Frozen upstream: 1fe0f2f3ac97",
+        "Downstream revision:",
+        "Update channel: stable",
+        "Install directory:",
+        "Python:",
+        "OpenAI SDK:",
+    ):
         assert field in out, f"fast --version output missing {field!r}:\n{out}"
 
 

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -349,7 +349,9 @@ class TestReadmeNoLongerSaysWindowsUnsupported:
         root = Path(__file__).resolve().parents[2]
         source = (root / "README.md").read_text(encoding="utf-8")
         assert "git clone https://github.com/zapabob/hermes-agent-windows.git" in source
-        assert "no verified fork-specific binary installer" in source
+        assert "The Windows release workflow produces a per-user NSIS installer" in source
+        assert "https://github.com/zapabob/hermes-agent-windows/releases" in source
+        assert "no verified fork-specific binary installer" not in source
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Outcome

Adds the Windows Workstation Edition distribution authority, installer and portable qualification, upgrade E2E, release manifest and notes, stable/preview policy, privacy-safe workstation evidence, reproducible isolated demo, and exact-SHA Windows release workflow.

## Candidate evidence

- Candidate SHA: e858df5d45fbb34ae9f6752847f3336685fceb0d
- Frozen upstream SHA: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
- Local Windows qualification: all required gates passed
- Installer, portable, and 0.17.0 upgrade E2E: passed
- Isolated demo: clean install, CLI version, Desktop launch, and downstream identity passed
- Local llama and embedding services were not running; real-workstation evidence remains incomplete and is not represented as a release gate
- Local artifacts are unsigned; signing status remains explicit in the release manifest

Stable publication remains tag-only after this exact candidate and the same main SHA pass their required workflows.