### PR TITLE
fix(release): disable implicit Electron publishing

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -85,7 +85,7 @@ jobs:
         shell: pwsh
         run: |
           npm --workspace apps/desktop run build
-          npm --workspace apps/desktop run builder -- --win nsis zip
+          npm --workspace apps/desktop run builder -- --win nsis zip --publish never
 
       - id: current
         name: Resolve current artifacts
@@ -130,7 +130,7 @@ jobs:
           try {
             npm ci --no-audit --no-fund
             npm --workspace apps/desktop run build
-            npm --workspace apps/desktop run builder -- --win nsis --config.directories.output=$baselineOutput
+            npm --workspace apps/desktop run builder -- --win nsis --publish never --config.directories.output=$baselineOutput
           } finally {
             Pop-Location
           }

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434169,
+    "all_fork_specific_loc": 434181,
     "carry_surface_files": 959,
     "cwc": 156111,
-    "fork_owned_loc": 315431,
+    "fork_owned_loc": 315443,
     "upstream_owned_fork_loc": 118738,
-    "utr": 0.273483
+    "utr": 0.273476
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434169 |
+| All fork-specific LOC | 434181 |
 | Upstream-owned fork LOC | 118738 |
-| Fork-owned LOC | 315431 |
-| UTR | 0.273483 |
+| Fork-owned LOC | 315443 |
+| UTR | 0.273476 |
 | Carry Surface | 959 files |
 | CWC | 156111 |
 

--- a/tests/downstream/test_ci_contracts.py
+++ b/tests/downstream/test_ci_contracts.py
@@ -105,3 +105,15 @@ def test_external_actions_are_commit_pinned() -> None:
             assert action.match(reference), (
                 f"unpinned action in {path.name}: {reference}"
             )
+
+
+def test_release_builds_never_implicitly_publish_from_electron_builder() -> None:
+    commands = _step_commands(
+        _workflow(RELEASE)["jobs"]["build-qualify-release"]
+    )
+
+    builder_commands = [
+        line.strip() for line in commands.splitlines() if "run builder --" in line
+    ]
+    assert len(builder_commands) == 2
+    assert all("--publish never" in command for command in builder_commands)


### PR DESCRIPTION
## Root cause

Electron Builder auto-detected GitHub Actions and attempted an implicit publish during the non-publishing main preview build. No GH_TOKEN is intentionally exposed to that build step, so packaging failed after producing the installer.

## Fix

Pass --publish never to both current and baseline Electron Builder commands. Tag publication remains owned exclusively by the later exact-SHA GitHub Release step. A workflow contract test now requires every builder command in this workflow to disable implicit publishing. Carry-surface metrics are regenerated for the final diff.

- Candidate SHA: f5bceb66f019c029b943ab4ccef92ba120e04166
- Frozen upstream SHA: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
- Workflow YAML parse: passed
- Focused release workflow tests: 22 passed
- Carry metrics check: passed