### PR TITLE
fix(release): write portable checksum manifest

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434181,
+    "all_fork_specific_loc": 434185,
     "carry_surface_files": 959,
     "cwc": 156111,
-    "fork_owned_loc": 315443,
+    "fork_owned_loc": 315447,
     "upstream_owned_fork_loc": 118738,
-    "utr": 0.273476
+    "utr": 0.273473
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434181 |
+| All fork-specific LOC | 434185 |
 | Upstream-owned fork LOC | 118738 |
-| Fork-owned LOC | 315443 |
-| UTR | 0.273476 |
+| Fork-owned LOC | 315447 |
+| UTR | 0.273473 |
 | Carry Surface | 959 files |
 | CWC | 156111 |
 

--- a/scripts/downstream/generate_release_manifest.py
+++ b/scripts/downstream/generate_release_manifest.py
@@ -138,7 +138,7 @@ def generate_release_bundle(
         json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
     )
     sums = "".join(f"{item['sha256']}  {item['name']}\n" for item in artifacts)
-    (output_dir / "SHA256SUMS.txt").write_text(sums, encoding="utf-8")
+    (output_dir / "SHA256SUMS.txt").write_bytes(sums.encode("utf-8"))
     (output_dir / "RELEASE_NOTES.md").write_text(
         build_release_notes(manifest, Path(__file__).resolve().parents[2]),
         encoding="utf-8",

--- a/tests/downstream/test_windows_release_manifest.py
+++ b/tests/downstream/test_windows_release_manifest.py
@@ -76,7 +76,11 @@ def test_release_bundle_contains_required_identity_hashes_and_truthful_signing(
 
     on_disk = json.loads((output / "release-manifest.json").read_text(encoding="utf-8"))
     assert on_disk == manifest
-    sums = (output / "SHA256SUMS.txt").read_text(encoding="utf-8")
+    sums_path = output / "SHA256SUMS.txt"
+    sums_bytes = sums_path.read_bytes()
+    assert b"\r" not in sums_bytes
+    assert sums_bytes.endswith(b"\n")
+    sums = sums_bytes.decode("utf-8")
     assert artifacts["installer"]["name"] in sums
     assert artifacts["portable"]["name"] in sums
     notes = (output / "RELEASE_NOTES.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Root cause

The preview bundle generated SHA256SUMS.txt with CRLF on Windows. GNU sha256sum treated the carriage return as part of each file name, so cross-platform verification failed even though the recorded digests were correct.

## Fix

Write SHA256SUMS.txt as explicit UTF-8 bytes with LF delimiters and regress the byte-level newline contract. Carry metrics are current for this exact diff.

- Candidate SHA: 27a3bb50b6a253d08876071c7907a18346baf4e9
- Frozen upstream SHA: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
- Manifest tests: 3 passed
- Carry metrics check: passed