### PR TITLE
fix(ci): trust sandbox CA for npm E2E

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,8 +61,6 @@ jobs:
         id: classify
         uses: ./.github/actions/detect-changes
         with:
-          sparse-checkout: scripts/ci/classify_changes.py
-          sparse-checkout-cone-mode: false
           github-token: ${{ github.token }}
 
   # ─────────────────────────────────────────────────────────────────────

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434185,
-    "carry_surface_files": 959,
+    "all_fork_specific_loc": 434198,
+    "carry_surface_files": 960,
     "cwc": 156111,
-    "fork_owned_loc": 315447,
-    "upstream_owned_fork_loc": 118738,
-    "utr": 0.273473
+    "fork_owned_loc": 315456,
+    "upstream_owned_fork_loc": 118742,
+    "utr": 0.273474
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434198,
-    "carry_surface_files": 960,
+    "all_fork_specific_loc": 434215,
+    "carry_surface_files": 961,
     "cwc": 156111,
-    "fork_owned_loc": 315456,
-    "upstream_owned_fork_loc": 118742,
-    "utr": 0.273474
+    "fork_owned_loc": 315471,
+    "upstream_owned_fork_loc": 118744,
+    "utr": 0.273468
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434198 |
-| Upstream-owned fork LOC | 118742 |
-| Fork-owned LOC | 315456 |
-| UTR | 0.273474 |
-| Carry Surface | 960 files |
+| All fork-specific LOC | 434215 |
+| Upstream-owned fork LOC | 118744 |
+| Fork-owned LOC | 315471 |
+| UTR | 0.273468 |
+| Carry Surface | 961 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434185 |
-| Upstream-owned fork LOC | 118738 |
-| Fork-owned LOC | 315447 |
-| UTR | 0.273473 |
-| Carry Surface | 959 files |
+| All fork-specific LOC | 434198 |
+| Upstream-owned fork LOC | 118742 |
+| Fork-owned LOC | 315456 |
+| UTR | 0.273474 |
+| Carry Surface | 960 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,6 +196,8 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
+# Node connects to the local MITM proxy, so it must trust the sandbox CA.
+# proxy.py alone uses real-ca.pem for its separate outbound TLS connection.
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -216,7 +218,7 @@ exec bwrap \
   --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
   --setenv SSL_CERT_FILE /work/certs/ca.pem \
   --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \

--- a/tests/downstream/test_ci_contracts.py
+++ b/tests/downstream/test_ci_contracts.py
@@ -10,6 +10,8 @@ WORKFLOW = ROOT / ".github/workflows/fork-cicd.yml"
 SCHEDULED = ROOT / ".github/workflows/windows-full-qualification.yml"
 RELEASE = ROOT / ".github/workflows/windows-release.yml"
 SANDBOX_STAGE2 = ROOT / "scripts/sandbox/stage2-run.sh"
+CI = ROOT / ".github/workflows/ci.yaml"
+DETECT_ACTION = ROOT / ".github/actions/detect-changes/action.yml"
 
 
 def _workflow(path: Path) -> dict:
@@ -126,3 +128,16 @@ def test_sandbox_node_trusts_the_local_mitm_ca() -> None:
     assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem" in stage2
     assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem" not in stage2
     assert "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem" in stage2
+
+
+def test_ci_detect_step_passes_only_declared_action_inputs() -> None:
+    workflow = _workflow(CI)
+    action = _workflow(DETECT_ACTION)
+    detect_step = next(
+        step
+        for step in workflow["jobs"]["detect"]["steps"]
+        if step.get("uses") == "./.github/actions/detect-changes"
+    )
+    passed_inputs = set(detect_step.get("with", {}))
+    assert passed_inputs == {"github-token"}
+    assert passed_inputs <= set(action.get("inputs", {}))

--- a/tests/downstream/test_ci_contracts.py
+++ b/tests/downstream/test_ci_contracts.py
@@ -9,6 +9,7 @@ ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github/workflows/fork-cicd.yml"
 SCHEDULED = ROOT / ".github/workflows/windows-full-qualification.yml"
 RELEASE = ROOT / ".github/workflows/windows-release.yml"
+SANDBOX_STAGE2 = ROOT / "scripts/sandbox/stage2-run.sh"
 
 
 def _workflow(path: Path) -> dict:
@@ -117,3 +118,11 @@ def test_release_builds_never_implicitly_publish_from_electron_builder() -> None
     ]
     assert len(builder_commands) == 2
     assert all("--publish never" in command for command in builder_commands)
+
+
+def test_sandbox_node_trusts_the_local_mitm_ca() -> None:
+    stage2 = SANDBOX_STAGE2.read_text(encoding="utf-8")
+
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem" in stage2
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem" not in stage2
+    assert "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem" in stage2


### PR DESCRIPTION
## Summary

- make Node/npm trust the sandbox MITM CA used by the install/update E2E proxy
- keep the proxy outbound connection pinned to the host real CA bundle
- add a regression contract for the two distinct trust boundaries
- refresh the carry-surface reports

## Evidence

- `bash -n scripts/sandbox/stage2-run.sh`
- `uv lock --check`
- `uv run pytest tests/downstream/test_ci_contracts.py tests/downstream/test_distribution_metadata.py tests/downstream/test_carry_metrics.py -q` (22 passed)
- failure evidence: tag run 33045063523 failed both routes at npm with proxy-side TLS EOF while curl/Python/Git succeeded

The unpublished failed tag was withdrawn before a GitHub Release was created. Stable tagging will resume only after exact-head and exact-main validation.