### PR TITLE
test(tui): wait for resumed status render

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434215,
-    "carry_surface_files": 961,
+    "all_fork_specific_loc": 434217,
+    "carry_surface_files": 962,
     "cwc": 156111,
     "fork_owned_loc": 315471,
-    "upstream_owned_fork_loc": 118744,
-    "utr": 0.273468
+    "upstream_owned_fork_loc": 118746,
+    "utr": 0.273472
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434215 |
-| Upstream-owned fork LOC | 118744 |
+| All fork-specific LOC | 434217 |
+| Upstream-owned fork LOC | 118746 |
 | Fork-owned LOC | 315471 |
-| UTR | 0.273468 |
-| Carry Surface | 961 files |
+| UTR | 0.273472 |
+| Carry Surface | 962 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
+++ b/ui-tui/src/__tests__/appChromeBlockedTimers.test.tsx
@@ -295,7 +295,7 @@ describe('status-chrome timers under an occluding overlay', () => {
     nowSpy.mockReturnValue(T0 + 300_000)
     rule.clear()
     resetOverlayState()
-    await flush()
+    await vi.waitFor(() => expect(rule.output()).toContain('6m 0s'))
 
     const resumed = rule.output()
 


### PR DESCRIPTION
## Summary
- wait for the resumed status render by observable output instead of a fixed 20 ms delay
- preserve the wall-clock resynchronization assertions and timer-count contract
- refresh generated downstream carry-surface metrics

## Evidence
- main CI exposed the timing race: https://github.com/zapabob/hermes-agent-windows/actions/runs/33049031453
- focused test passed 11 consecutive runs, 29/29 each run
- `npm run check --prefix ui-tui`: 158 files passed, 1 skipped; 1706 tests passed, 8 skipped; typecheck and lint completed with no errors
- `uv run --locked pytest tests/downstream/test_carry_metrics.py tests/downstream/test_ci_contracts.py -q`: 13 passed
- `uv lock --check` and `git diff --check` passed