### PR TITLE
chore(downstream): refresh carry-surface metrics

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434217,
+    "all_fork_specific_loc": 434361,
     "carry_surface_files": 962,
     "cwc": 156111,
-    "fork_owned_loc": 315471,
-    "upstream_owned_fork_loc": 118746,
-    "utr": 0.273472
+    "fork_owned_loc": 315611,
+    "upstream_owned_fork_loc": 118750,
+    "utr": 0.27339
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434217 |
-| Upstream-owned fork LOC | 118746 |
-| Fork-owned LOC | 315471 |
-| UTR | 0.273472 |
+| All fork-specific LOC | 434361 |
+| Upstream-owned fork LOC | 118750 |
+| Fork-owned LOC | 315611 |
+| UTR | 0.273390 |
 | Carry Surface | 962 files |
 | CWC | 156111 |
 


### PR DESCRIPTION
## Summary

- regenerate the downstream carry-surface JSON and Markdown ledgers after formatter-only main changes
- keep the frozen upstream snapshot at `1fe0f2f3ac9748ce799272eb93bee2937b5ab802`
- restore the Windows Tier-1 carry-metrics contract

## Verification

- `uv run --no-sync python -m pytest tests/downstream/test_carry_metrics.py -q`
- `uv run --no-sync python scripts/downstream/carry_metrics.py --check`
- `git diff --check`