### PR TITLE
fix(sandbox): retry transient outbound TLS EOF

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434465,
-    "carry_surface_files": 963,
+    "all_fork_specific_loc": 434471,
+    "carry_surface_files": 964,
     "cwc": 156111,
     "fork_owned_loc": 315680,
-    "upstream_owned_fork_loc": 118785,
-    "utr": 0.273405
+    "upstream_owned_fork_loc": 118791,
+    "utr": 0.273415
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434361,
-    "carry_surface_files": 962,
+    "all_fork_specific_loc": 434465,
+    "carry_surface_files": 963,
     "cwc": 156111,
-    "fork_owned_loc": 315611,
-    "upstream_owned_fork_loc": 118750,
-    "utr": 0.27339
+    "fork_owned_loc": 315680,
+    "upstream_owned_fork_loc": 118785,
+    "utr": 0.273405
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434465 |
-| Upstream-owned fork LOC | 118785 |
+| All fork-specific LOC | 434471 |
+| Upstream-owned fork LOC | 118791 |
 | Fork-owned LOC | 315680 |
-| UTR | 0.273405 |
-| Carry Surface | 963 files |
+| UTR | 0.273415 |
+| Carry Surface | 964 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434361 |
-| Upstream-owned fork LOC | 118750 |
-| Fork-owned LOC | 315611 |
-| UTR | 0.273390 |
-| Carry Surface | 962 files |
+| All fork-specific LOC | 434465 |
+| Upstream-owned fork LOC | 118785 |
+| Fork-owned LOC | 315680 |
+| UTR | 0.273405 |
+| Carry Surface | 963 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -24,6 +24,7 @@ import ssl
 import subprocess
 import sys
 import threading
+import time
 from urllib.parse import unquote, urlsplit
 
 ROOT, CERTS, REAL_CA = map(pathlib.Path, sys.argv[1:])
@@ -31,6 +32,8 @@ ROOT, CERTS, REAL_CA = map(pathlib.Path, sys.argv[1:])
 LISTEN_ADDRESS = ('127.0.0.1', 8080)
 MAX_REQUEST_BYTES = 65536
 UPSTREAM_TIMEOUT_SECONDS = 30
+UPSTREAM_TLS_HANDSHAKE_ATTEMPTS = 3
+UPSTREAM_TLS_RETRY_DELAY_SECONDS = 0.25
 CERT_VALIDITY_DAYS = 2
 
 
@@ -150,12 +153,36 @@ def relay(source, destination):
         destination.sendall(chunk)
 
 
+def open_https_upstream(context, host, port):
+    """Open verified upstream TLS, retrying only pre-request EOF failures.
+
+    npm opens several parallel connections through the sandbox proxy. GitHub's
+    hosted runner network can occasionally close one during the TLS handshake.
+    Retrying at this boundary is safe because no HTTP request bytes have been
+    sent yet. All other TLS failures, including certificate verification, are
+    permanent for this request and must remain visible immediately.
+    """
+    for attempt in range(1, UPSTREAM_TLS_HANDSHAKE_ATTEMPTS + 1):
+        raw = socket.create_connection(
+            (host, port), timeout=UPSTREAM_TIMEOUT_SECONDS
+        )
+        try:
+            return context.wrap_socket(raw, server_hostname=host)
+        except ssl.SSLEOFError:
+            raw.close()
+            if attempt == UPSTREAM_TLS_HANDSHAKE_ATTEMPTS:
+                raise
+            time.sleep(UPSTREAM_TLS_RETRY_DELAY_SECONDS * attempt)
+        except Exception:
+            raw.close()
+            raise
+
+
 def forward_https(conn, host, port, request):
     context = ssl.create_default_context(cafile=str(REAL_CA))
-    with socket.create_connection((host, port), timeout=UPSTREAM_TIMEOUT_SECONDS) as raw:
-        with context.wrap_socket(raw, server_hostname=host) as upstream:
-            upstream.sendall(close_request(request))
-            relay(upstream, conn)
+    with open_https_upstream(context, host, port) as upstream:
+        upstream.sendall(close_request(request))
+        relay(upstream, conn)
 
 
 def forward_http(conn, host, port, request, target):

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -490,13 +490,15 @@ def test_turn_lease_fences_stale_transcript_flush_after_reclaim(tmp_path):
     db.release_session_turn_lease("shared", next_holder)
 
 
-def test_turn_lease_revives_expired_row_still_owned_by_writer(tmp_path):
+def test_turn_lease_revives_expired_row_still_owned_by_writer(tmp_path, monkeypatch):
     db = SessionDB(tmp_path / "state.db")
     db.create_session("shared", source="test")
     holder = f"pid={os.getpid()}:turn=owner"
+    now = 1_000_000.0
+    monkeypatch.setattr(hermes_state.time, "time", lambda: now)
 
     assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=0.05)
-    time.sleep(0.12)
+    now += 0.12
     assert db.append_messages_batch(
         "shared",
         [{"role": "assistant", "content": "after ttl"}],

--- a/tests/test_dev_sandbox_proxy.py
+++ b/tests/test_dev_sandbox_proxy.py
@@ -1,0 +1,69 @@
+"""Regression tests for the dev sandbox's outbound HTTPS boundary."""
+
+from __future__ import annotations
+
+import importlib.util
+import ssl
+import sys
+from pathlib import Path
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROXY_PATH = ROOT / "scripts" / "sandbox" / "proxy.py"
+
+
+def _load_proxy(tmp_path: Path):
+    spec = importlib.util.spec_from_file_location("dev_sandbox_proxy", PROXY_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    argv = ["proxy.py", str(tmp_path), str(tmp_path), str(tmp_path / "ca.pem")]
+    with patch.object(sys, "argv", argv):
+        spec.loader.exec_module(module)
+    return module
+
+
+def test_https_handshake_eof_retries_before_any_request(tmp_path: Path) -> None:
+    proxy = _load_proxy(tmp_path)
+    raw_connections = [Mock(), Mock(), Mock()]
+    upstream = Mock()
+    context = Mock()
+    context.wrap_socket.side_effect = [
+        ssl.SSLEOFError(8, "unexpected EOF"),
+        ssl.SSLEOFError(8, "unexpected EOF"),
+        upstream,
+    ]
+
+    with (
+        patch.object(proxy.socket, "create_connection", side_effect=raw_connections),
+        patch.object(proxy.time, "sleep") as sleep,
+    ):
+        result = proxy.open_https_upstream(context, "registry.npmjs.org", 443)
+
+    assert result is upstream
+    assert raw_connections[0].close.call_count == 1
+    assert raw_connections[1].close.call_count == 1
+    assert raw_connections[2].close.call_count == 0
+    assert sleep.call_args_list == [call(0.25), call(0.5)]
+
+
+def test_https_certificate_failure_is_not_retried(tmp_path: Path) -> None:
+    proxy = _load_proxy(tmp_path)
+    raw = Mock()
+    context = Mock()
+    context.wrap_socket.side_effect = ssl.SSLCertVerificationError(
+        1, "certificate verify failed"
+    )
+
+    with (
+        patch.object(proxy.socket, "create_connection", return_value=raw) as connect,
+        patch.object(proxy.time, "sleep") as sleep,
+    ):
+        with pytest.raises(ssl.SSLCertVerificationError):
+            proxy.open_https_upstream(context, "registry.npmjs.org", 443)
+
+    assert connect.call_count == 1
+    assert raw.close.call_count == 1
+    sleep.assert_not_called()


### PR DESCRIPTION
## Summary

- retry only ssl.SSLEOFError failures that occur before any upstream HTTP request bytes are sent
- close failed raw sockets and keep certificate verification or other TLS failures fail-fast
- add regression coverage for bounded EOF recovery and non-retryable certificate failures

## Evidence

- uv run --no-sync python -m pytest tests/downstream tests/test_dev_sandbox_proxy.py -q: 73 passed
- uv run --no-sync ruff check scripts/sandbox/proxy.py tests/test_dev_sandbox_proxy.py: passed
- uv run --no-sync ruff format --check tests/test_dev_sandbox_proxy.py: passed
- uv run --no-sync python -m py_compile scripts/sandbox/proxy.py tests/test_dev_sandbox_proxy.py: passed
- git diff --check: passed

## Release boundary

The previous v0.20.5-win.1 attempt was cancelled before release publication and the tag was withdrawn. A new stable tag will be issued only after exact-head CI and tag installer/update E2E both pass.