### PR TITLE
fix(sandbox): serialize outbound TLS handshakes

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434471,
+    "all_fork_specific_loc": 434555,
     "carry_surface_files": 964,
     "cwc": 156111,
-    "fork_owned_loc": 315680,
-    "upstream_owned_fork_loc": 118791,
-    "utr": 0.273415
+    "fork_owned_loc": 315754,
+    "upstream_owned_fork_loc": 118801,
+    "utr": 0.273385
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434471 |
-| Upstream-owned fork LOC | 118791 |
-| Fork-owned LOC | 315680 |
-| UTR | 0.273415 |
+| All fork-specific LOC | 434555 |
+| Upstream-owned fork LOC | 118801 |
+| Fork-owned LOC | 315754 |
+| UTR | 0.273385 |
 | Carry Surface | 964 files |
 | CWC | 156111 |
 

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -32,8 +32,9 @@ ROOT, CERTS, REAL_CA = map(pathlib.Path, sys.argv[1:])
 LISTEN_ADDRESS = ('127.0.0.1', 8080)
 MAX_REQUEST_BYTES = 65536
 UPSTREAM_TIMEOUT_SECONDS = 30
-UPSTREAM_TLS_HANDSHAKE_ATTEMPTS = 3
+UPSTREAM_TLS_HANDSHAKE_ATTEMPTS = 6
 UPSTREAM_TLS_RETRY_DELAY_SECONDS = 0.25
+UPSTREAM_TLS_MAX_RETRY_DELAY_SECONDS = 2.0
 CERT_VALIDITY_DAYS = 2
 
 
@@ -66,6 +67,7 @@ def run_openssl(args):
 
 
 _CERT_LOCK = threading.Lock()
+_UPSTREAM_TLS_HANDSHAKE_LOCK = threading.Lock()
 
 
 def cert_for(host):
@@ -162,20 +164,28 @@ def open_https_upstream(context, host, port):
     sent yet. All other TLS failures, including certificate verification, are
     permanent for this request and must remain visible immediately.
     """
-    for attempt in range(1, UPSTREAM_TLS_HANDSHAKE_ATTEMPTS + 1):
-        raw = socket.create_connection(
-            (host, port), timeout=UPSTREAM_TIMEOUT_SECONDS
-        )
-        try:
-            return context.wrap_socket(raw, server_hostname=host)
-        except ssl.SSLEOFError:
-            raw.close()
-            if attempt == UPSTREAM_TLS_HANDSHAKE_ATTEMPTS:
+    # npm starts several downloads together. Serializing only the TLS
+    # handshakes prevents those connections from retrying in lockstep through
+    # slirp4netns; established connections still relay concurrently.
+    with _UPSTREAM_TLS_HANDSHAKE_LOCK:
+        for attempt in range(1, UPSTREAM_TLS_HANDSHAKE_ATTEMPTS + 1):
+            raw = socket.create_connection(
+                (host, port), timeout=UPSTREAM_TIMEOUT_SECONDS
+            )
+            try:
+                return context.wrap_socket(raw, server_hostname=host)
+            except ssl.SSLEOFError:
+                raw.close()
+                if attempt == UPSTREAM_TLS_HANDSHAKE_ATTEMPTS:
+                    raise
+                delay = min(
+                    UPSTREAM_TLS_RETRY_DELAY_SECONDS * (2 ** (attempt - 1)),
+                    UPSTREAM_TLS_MAX_RETRY_DELAY_SECONDS,
+                )
+                time.sleep(delay)
+            except Exception:
+                raw.close()
                 raise
-            time.sleep(UPSTREAM_TLS_RETRY_DELAY_SECONDS * attempt)
-        except Exception:
-            raw.close()
-            raise
 
 
 def forward_https(conn, host, port, request):

--- a/tests/test_dev_sandbox_proxy.py
+++ b/tests/test_dev_sandbox_proxy.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 import ssl
 import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest.mock import Mock, call, patch
 
@@ -67,3 +69,75 @@ def test_https_certificate_failure_is_not_retried(tmp_path: Path) -> None:
     assert connect.call_count == 1
     assert raw.close.call_count == 1
     sleep.assert_not_called()
+
+
+def test_https_handshake_eof_exhausts_bounded_backoff(tmp_path: Path) -> None:
+    proxy = _load_proxy(tmp_path)
+    raw_connections = [Mock() for _ in range(proxy.UPSTREAM_TLS_HANDSHAKE_ATTEMPTS)]
+    context = Mock()
+    context.wrap_socket.side_effect = [
+        ssl.SSLEOFError(8, "unexpected EOF") for _ in raw_connections
+    ]
+
+    with (
+        patch.object(proxy.socket, "create_connection", side_effect=raw_connections),
+        patch.object(proxy.time, "sleep") as sleep,
+    ):
+        with pytest.raises(ssl.SSLEOFError):
+            proxy.open_https_upstream(context, "registry.npmjs.org", 443)
+
+    assert all(raw.close.call_count == 1 for raw in raw_connections)
+    assert sleep.call_args_list == [
+        call(0.25),
+        call(0.5),
+        call(1.0),
+        call(2.0),
+        call(2.0),
+    ]
+
+
+def test_https_handshakes_are_serialized(tmp_path: Path) -> None:
+    proxy = _load_proxy(tmp_path)
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_invoked = threading.Event()
+    second_entered = threading.Event()
+    upstreams = [Mock(), Mock()]
+    context = Mock()
+    call_count = 0
+
+    def wrap_socket(raw, *, server_hostname):
+        nonlocal call_count
+        assert server_hostname == "registry.npmjs.org"
+        call_count += 1
+        if call_count == 1:
+            first_entered.set()
+            assert release_first.wait(timeout=1)
+        else:
+            second_entered.set()
+        return upstreams[call_count - 1]
+
+    def open_second():
+        second_invoked.set()
+        return proxy.open_https_upstream(context, "registry.npmjs.org", 443)
+
+    context.wrap_socket.side_effect = wrap_socket
+    with (
+        patch.object(
+            proxy.socket, "create_connection", side_effect=[Mock(), Mock()]
+        ) as connect,
+        ThreadPoolExecutor(max_workers=2) as pool,
+    ):
+        first = pool.submit(
+            proxy.open_https_upstream, context, "registry.npmjs.org", 443
+        )
+        assert first_entered.wait(timeout=1)
+        second = pool.submit(open_second)
+        assert second_invoked.wait(timeout=1)
+        assert not second_entered.wait(timeout=0.1)
+        release_first.set()
+
+        assert first.result(timeout=1) is upstreams[0]
+        assert second.result(timeout=1) is upstreams[1]
+
+    assert connect.call_count == 2


### PR DESCRIPTION
## Summary

- serialize only upstream TLS handshakes in the dev-sandbox MITM proxy so npm download threads do not retry in lockstep through slirp4netns
- increase pre-request EOF retries from 3 to 6 with bounded exponential backoff
- keep certificate failures non-retriable and preserve the no-request-replay boundary
- add bounded-backoff and concurrent-handshake regression coverage
- refresh generated carry-surface metrics

## Failure evidence

Stable-tag Install & Update E2E run 33072106322 failed in both installer and update jobs after concurrent npm connections exhausted the previous three handshake attempts. Release run 33072106109 was cancelled before publication. No GitHub Release exists for the tag.

## Local verification

- `tests/test_dev_sandbox_proxy.py`: 4 passed
- proxy test file repeated 32 times: all passed
- proxy + downstream CI-contract + carry-metrics tests: 17 passed
- Ruff check: passed
- test-file Ruff format check: passed
- Python compile: passed
- carry metrics `--check`: passed
- `git diff --check`: passed
