### PR TITLE
fix(sandbox): close forwarded keepalive requests

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434555,
+    "all_fork_specific_loc": 434579,
     "carry_surface_files": 964,
     "cwc": 156111,
-    "fork_owned_loc": 315754,
-    "upstream_owned_fork_loc": 118801,
-    "utr": 0.273385
+    "fork_owned_loc": 315773,
+    "upstream_owned_fork_loc": 118806,
+    "utr": 0.273382
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434555 |
-| Upstream-owned fork LOC | 118801 |
-| Fork-owned LOC | 315754 |
-| UTR | 0.273385 |
+| All fork-specific LOC | 434579 |
+| Upstream-owned fork LOC | 118806 |
+| Fork-owned LOC | 315773 |
+| UTR | 0.273382 |
 | Carry Surface | 964 files |
 | CWC | 156111 |
 

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -140,8 +140,9 @@ def close_request(request, target=None):
         method, _, version = lines[0].split(b' ', 2)
         lines[0] = b' '.join((method, target.encode(), version))
     lines = [
-        line for line in lines
-        if not line.lower().startswith(b'proxy-connection:')
+        line
+        for line in lines
+        if not line.lower().startswith((b'connection:', b'proxy-connection:'))
     ]
     lines.append(b'Connection: close')
     return b'\r\n'.join(lines) + separator + body

--- a/tests/test_dev_sandbox_proxy.py
+++ b/tests/test_dev_sandbox_proxy.py
@@ -71,6 +71,25 @@ def test_https_certificate_failure_is_not_retried(tmp_path: Path) -> None:
     sleep.assert_not_called()
 
 
+def test_close_request_replaces_keep_alive_headers(tmp_path: Path) -> None:
+    proxy = _load_proxy(tmp_path)
+    request = (
+        b"GET /package HTTP/1.1\r\n"
+        b"Host: registry.npmjs.org\r\n"
+        b"Connection: keep-alive\r\n"
+        b"Proxy-Connection: keep-alive\r\n"
+        b"X-Request: preserved\r\n\r\nbody"
+    )
+
+    closed = proxy.close_request(request)
+
+    assert b"Connection: keep-alive" not in closed
+    assert b"Proxy-Connection: keep-alive" not in closed
+    assert closed.count(b"Connection: close") == 1
+    assert b"X-Request: preserved\r\n" in closed
+    assert closed.endswith(b"\r\n\r\nbody")
+
+
 def test_https_handshake_eof_exhausts_bounded_backoff(tmp_path: Path) -> None:
     proxy = _load_proxy(tmp_path)
     raw_connections = [Mock() for _ in range(proxy.UPSTREAM_TLS_HANDSHAKE_ATTEMPTS)]


### PR DESCRIPTION
## Summary

- remove existing `Connection` and `Proxy-Connection` headers before forwarding
- send exactly one `Connection: close` header upstream
- preserve the proxy's one-request-per-intercepted-connection contract without waiting forever on npm keep-alive sockets
- add a byte-level regression test for header replacement and body preservation
- refresh generated carry-surface metrics

## Failure evidence

Stable-tag E2E run 33078217880 showed no TLS EOF after PR #89, but both npm installs waited 60 seconds and failed without any proxy exception. The proxy was appending `Connection: close` while retaining npm's `Connection: keep-alive`, allowing upstream reuse while the proxy only reads one nested request. Release run 33078217413 was cancelled before publication; no GitHub Release exists.

## Local verification

- proxy tests: 5 passed
- proxy test file repeated 32 times: all passed
- proxy + downstream CI-contract + carry-metrics tests: 18 passed
- Ruff check: passed
- test-file Ruff format check: passed
- Python compile: passed
- carry metrics `--check`: passed
- `git diff --check`: passed
