### PR TITLE
fix(ci): tunnel non-fixture sandbox HTTPS end to end

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434579,
-    "carry_surface_files": 964,
+    "all_fork_specific_loc": 434684,
+    "carry_surface_files": 965,
     "cwc": 156111,
-    "fork_owned_loc": 315773,
-    "upstream_owned_fork_loc": 118806,
-    "utr": 0.273382
+    "fork_owned_loc": 315832,
+    "upstream_owned_fork_loc": 118852,
+    "utr": 0.273422
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434579 |
-| Upstream-owned fork LOC | 118806 |
-| Fork-owned LOC | 315773 |
-| UTR | 0.273382 |
-| Carry Surface | 964 files |
+| All fork-specific LOC | 434684 |
+| Upstream-owned fork LOC | 118852 |
+| Fork-owned LOC | 315832 |
+| UTR | 0.273422 |
+| Carry Surface | 965 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -444,6 +444,13 @@ if [ ! -f "$SANDBOX_ROOT/root/certs/ca.pem" ]; then
     exit 1
   fi
 fi
+# Fixture hosts terminate TLS at proxy.py and use the sandbox CA. Every other
+# HTTPS host is carried through a raw CONNECT tunnel and presents its public
+# certificate directly, so clients need both trust sets in one deterministic
+# bundle. Keep ca.pem separate because openssl uses it to sign fixture leaves.
+cat "$SANDBOX_ROOT/root/certs/ca.pem" \
+    "$SANDBOX_ROOT/root/certs/real-ca.pem" \
+    > "$SANDBOX_ROOT/root/certs/client-ca.pem"
 GIT_UPLOAD_PACK="$(command -v git-upload-pack)"
 sed "s|@GIT_UPLOAD_PACK@|$GIT_UPLOAD_PACK|" "$SANDBOX_ASSETS/ssh-shim.sh" \
   > "$SANDBOX_ROOT/root/usr/bin/ssh"

--- a/scripts/sandbox/proxy.py
+++ b/scripts/sandbox/proxy.py
@@ -19,6 +19,7 @@ Usage: proxy.py <fixture-root> <certs-dir> <real-ca-bundle>
 
 import os
 import pathlib
+import select
 import socket
 import ssl
 import subprocess
@@ -156,6 +157,29 @@ def relay(source, destination):
         destination.sendall(chunk)
 
 
+def host_has_fixtures(host):
+    """Return whether HTTPS for host must be intercepted for local fixtures."""
+    if not host or host in {'.', '..'} or '/' in host:
+        return False
+    return (ROOT / host).is_dir()
+
+
+def relay_tunnel(client, upstream):
+    """Relay an end-to-end CONNECT tunnel without terminating client TLS."""
+    peers = {client: upstream, upstream: client}
+    while True:
+        readable, _, _ = select.select(
+            tuple(peers), (), (), UPSTREAM_TIMEOUT_SECONDS
+        )
+        if not readable:
+            return
+        for source in readable:
+            chunk = source.recv(MAX_REQUEST_BYTES)
+            if not chunk:
+                return
+            peers[source].sendall(chunk)
+
+
 def open_https_upstream(context, host, port):
     """Open verified upstream TLS, retrying only pre-request EOF failures.
 
@@ -207,9 +231,16 @@ def forward_http(conn, host, port, request, target):
 
 
 def handle_connect(conn, target):
-    """Intercept a CONNECT tunnel, terminating TLS with a minted cert."""
+    """Serve fixture hosts via MITM and tunnel all other HTTPS end to end."""
     host, _, port_text = target.rpartition(':')
     port = int(port_text or '443')
+    if not host_has_fixtures(host):
+        with socket.create_connection(
+            (host, port), timeout=UPSTREAM_TIMEOUT_SECONDS
+        ) as upstream:
+            conn.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
+            relay_tunnel(conn, upstream)
+        return
     conn.sendall(b'HTTP/1.1 200 Connection Established\r\n\r\n')
     cert, key = cert_for(host)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -196,8 +196,8 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
-# Node connects to the local MITM proxy, so it must trust the sandbox CA.
-# proxy.py alone uses real-ca.pem for its separate outbound TLS connection.
+# Fixture hosts use the sandbox CA; end-to-end CONNECT tunnels use public CAs.
+# client-ca.pem contains both without changing the fixture-signing CA file.
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -215,10 +215,10 @@ exec bwrap \
   --setenv HOME "$DEV_SANDBOX_HOME" \
   --setenv USER "$DEV_SANDBOX_USER" \
   --setenv LOGNAME "$DEV_SANDBOX_USER" \
-  --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
-  --setenv SSL_CERT_FILE /work/certs/ca.pem \
-  --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
+  --setenv CURL_CA_BUNDLE /work/certs/client-ca.pem \
+  --setenv SSL_CERT_FILE /work/certs/client-ca.pem \
+  --setenv GIT_SSL_CAINFO /work/certs/client-ca.pem \
+  --setenv NODE_EXTRA_CA_CERTS /work/certs/client-ca.pem \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
   --setenv HTTP_PROXY http://127.0.0.1:8080 \
   --setenv HTTPS_PROXY http://127.0.0.1:8080 \

--- a/tests/downstream/test_ci_contracts.py
+++ b/tests/downstream/test_ci_contracts.py
@@ -84,7 +84,10 @@ def test_security_lane_checks_all_lock_ecosystems() -> None:
     assert "uv lock --check" in commands
     assert "uv export --frozen --all-extras --no-dev --no-emit-project" in commands
     assert "Join-Path $env:RUNNER_TEMP 'hermes-audit-requirements.txt'" in commands
-    assert "pip-audit==2.10.1 pip-audit --require-hashes --disable-pip --requirement" in commands
+    assert (
+        "pip-audit==2.10.1 pip-audit --require-hashes --disable-pip --requirement"
+        in commands
+    )
     assert "npm audit" in commands
     assert "go mod verify" in commands
 
@@ -111,9 +114,7 @@ def test_external_actions_are_commit_pinned() -> None:
 
 
 def test_release_builds_never_implicitly_publish_from_electron_builder() -> None:
-    commands = _step_commands(
-        _workflow(RELEASE)["jobs"]["build-qualify-release"]
-    )
+    commands = _step_commands(_workflow(RELEASE)["jobs"]["build-qualify-release"])
 
     builder_commands = [
         line.strip() for line in commands.splitlines() if "run builder --" in line
@@ -122,12 +123,15 @@ def test_release_builds_never_implicitly_publish_from_electron_builder() -> None
     assert all("--publish never" in command for command in builder_commands)
 
 
-def test_sandbox_node_trusts_the_local_mitm_ca() -> None:
+def test_sandbox_node_trusts_fixture_and_tunneled_https_cas() -> None:
     stage2 = SANDBOX_STAGE2.read_text(encoding="utf-8")
 
-    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem" in stage2
-    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem" not in stage2
-    assert "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem" in stage2
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/client-ca.pem" in stage2
+    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem" not in stage2
+    assert (
+        "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem"
+        in stage2
+    )
 
 
 def test_ci_detect_step_passes_only_declared_action_inputs() -> None:

--- a/tests/test_dev_sandbox_proxy.py
+++ b/tests/test_dev_sandbox_proxy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import socket
 import ssl
 import sys
 import threading
@@ -15,6 +16,8 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 PROXY_PATH = ROOT / "scripts" / "sandbox" / "proxy.py"
+DEV_SANDBOX_PATH = ROOT / "scripts" / "dev-sandbox.sh"
+STAGE2_PATH = ROOT / "scripts" / "sandbox" / "stage2-run.sh"
 
 
 def _load_proxy(tmp_path: Path):
@@ -88,6 +91,58 @@ def test_close_request_replaces_keep_alive_headers(tmp_path: Path) -> None:
     assert closed.count(b"Connection: close") == 1
     assert b"X-Request: preserved\r\n" in closed
     assert closed.endswith(b"\r\n\r\nbody")
+
+
+def test_non_fixture_https_is_relayed_as_end_to_end_tunnel(tmp_path: Path) -> None:
+    proxy = _load_proxy(tmp_path)
+    client, proxy_side = socket.socketpair()
+    upstream_side, server = socket.socketpair()
+    worker = threading.Thread(target=proxy.handle, args=(proxy_side,))
+
+    with (
+        patch.object(
+            proxy.socket, "create_connection", return_value=upstream_side
+        ) as connect,
+        patch.object(proxy, "cert_for") as cert_for,
+    ):
+        worker.start()
+        client.sendall(
+            b"CONNECT registry.npmjs.org:443 HTTP/1.1\r\n"
+            b"Host: registry.npmjs.org:443\r\n\r\n"
+        )
+        assert client.recv(4096) == b"HTTP/1.1 200 Connection Established\r\n\r\n"
+
+        client.sendall(b"client TLS bytes")
+        assert server.recv(4096) == b"client TLS bytes"
+        server.sendall(b"server TLS bytes")
+        assert client.recv(4096) == b"server TLS bytes"
+
+        client.shutdown(socket.SHUT_WR)
+        worker.join(timeout=1)
+
+    client.close()
+    server.close()
+    assert not worker.is_alive()
+    connect.assert_called_once_with(
+        ("registry.npmjs.org", 443), timeout=proxy.UPSTREAM_TIMEOUT_SECONDS
+    )
+    cert_for.assert_not_called()
+
+
+def test_client_trust_bundle_covers_fixture_and_tunneled_https() -> None:
+    sandbox = DEV_SANDBOX_PATH.read_text(encoding="utf-8")
+    stage2 = STAGE2_PATH.read_text(encoding="utf-8")
+
+    assert '"$SANDBOX_ROOT/root/certs/ca.pem"' in sandbox
+    assert '"$SANDBOX_ROOT/root/certs/real-ca.pem"' in sandbox
+    assert '> "$SANDBOX_ROOT/root/certs/client-ca.pem"' in sandbox
+    for variable in (
+        "CURL_CA_BUNDLE",
+        "SSL_CERT_FILE",
+        "GIT_SSL_CAINFO",
+        "NODE_EXTRA_CA_CERTS",
+    ):
+        assert f"--setenv {variable} /work/certs/client-ca.pem" in stage2
 
 
 def test_https_handshake_eof_exhausts_bounded_backoff(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- keep fixture-host HTTPS interception for the canonical installer URL
- carry every non-fixture CONNECT stream end to end so npm/PyPI own TLS and keepalive
- trust both the sandbox fixture CA and public roots through a deterministic client bundle
- exercise bidirectional raw tunnel bytes with a real socket-pair regression test

## Failure evidence

Stable-tag Install & Update E2E run 33085831287 exhausted upstream TLS handshakes in the update lane while the installer lane timed out npm with no proxy exception. Release run 33085830626 was cancelled before publication.

## Local evidence

- proxy regression suite: 7 passed
- proxy regression suite repeated: 32/32 passed
- proxy + downstream CI/carry contracts: 20 passed
- Ruff check and format: passed
- Python compile and bash syntax: passed
- carry metrics current: UTR 0.273422, 965 files, CWC 156111

Frozen upstream remains 1fe0f2f3ac9748ce799272eb93bee2937b5ab802.