### PR TITLE
fix(installer): bypass fixture proxy for dependencies

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "1fe0f2f3ac9748ce799272eb93bee2937b5ab802",
   "summary": {
-    "all_fork_specific_loc": 434579,
-    "carry_surface_files": 964,
+    "all_fork_specific_loc": 434651,
+    "carry_surface_files": 965,
     "cwc": 156111,
-    "fork_owned_loc": 315773,
-    "upstream_owned_fork_loc": 118806,
-    "utr": 0.273382
+    "fork_owned_loc": 315782,
+    "upstream_owned_fork_loc": 118869,
+    "utr": 0.273481
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: 1fe0f2f3ac9748ce799272eb93bee2937b5ab802
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 434579 |
-| Upstream-owned fork LOC | 118806 |
-| Fork-owned LOC | 315773 |
-| UTR | 0.273382 |
-| Carry Surface | 964 files |
+| All fork-specific LOC | 434651 |
+| Upstream-owned fork LOC | 118869 |
+| Fork-owned LOC | 315782 |
+| UTR | 0.273481 |
+| Carry Surface | 965 files |
 | CWC | 156111 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/scripts/dev-sandbox.sh
+++ b/scripts/dev-sandbox.sh
@@ -6,9 +6,9 @@
 # the user+network namespaces with `unshare` (see the namespace plan further
 # down), then re-execs into scripts/sandbox/stage2-run.sh, which adds the
 # mount/pid namespaces with bubblewrap and runs the payload. Its only writable
-# filesystem is SANDBOX_ROOT. HTTP(S) goes to a local static MITM proxy;
-# github.com SSH uses a sandbox-local git-upload-pack shim; neither transport
-# can reach the host network.
+# filesystem is SANDBOX_ROOT. Fixture HTTP(S) goes to a local static MITM proxy;
+# external HTTP(S) uses the private rootless network; github.com SSH uses a
+# sandbox-local git-upload-pack shim.
 
 set -euo pipefail
 
@@ -77,10 +77,12 @@ one. Both are worth testing; they differ in more than paths (root also relocates
 uv's Python to /usr/local/share for world-readability).
 
 The fake web server signs certificates with a CA trusted only inside this
-sandbox. HTTP_PROXY/HTTPS_PROXY send fixture URLs there first; other HTTP(S)
-requests pass through the sandbox's rootless outbound network. SSH to github.com
-runs a sandbox-local upload-pack shim, never your SSH config, agent,
-known-hosts file, or authorized keys.
+sandbox. The install shortcut fetches the canonical installer fixture through
+that server, then gives the installer and its dependency managers direct HTTPS
+through the sandbox's rootless outbound network. Generic --http-root commands
+retain the all-HTTP(S) proxy for fixture testing. SSH to github.com runs a
+sandbox-local upload-pack shim, never your SSH config, agent, known-hosts file,
+or authorized keys.
 
 Fake github main always comes from this folder. If it has staged, unstaged, or
 non-ignored untracked changes, the sandbox warns and creates a temporary local
@@ -174,6 +176,11 @@ fi
 if [ -n "$INSTALL_REF" ] && [ -n "$INSTALLER_PATH" ]; then
   echo 'error: --from-main / --install-ref cannot be combined with --installer' >&2
   exit 1
+fi
+
+DEV_SANDBOX_GLOBAL_PROXY_ENV=true
+if [ "$INSTALL_SHORTCUT" = true ]; then
+  DEV_SANDBOX_GLOBAL_PROXY_ENV=false
 fi
 
 for dir in "$SEED_DIR" "$HTTP_ROOT"; do
@@ -275,7 +282,8 @@ if [ "$INSTALL_SHORTCUT" = true ]; then
   fi
   set -- bash -c '
     set +e
-    curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- "$@"
+    curl --proxy http://127.0.0.1:8080 --cacert /work/certs/ca.pem \
+      -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- "$@"
     install_status=$?
     if [ "$install_status" -eq 0 ] && [ -f /work/promote-main ]; then
       next_main=$(cat /work/promote-main)
@@ -480,10 +488,6 @@ INTERACTIVE=false
 if [ -t 0 ] && [ -t 1 ]; then
   INTERACTIVE=true
 fi
-NODE_DIR="${DEV_SANDBOX_NODE_DIR:-}"
-if [ -z "$NODE_DIR" ] && command -v node >/dev/null; then
-  NODE_DIR="$(dirname "$(dirname "$(command -v node)")")"
-fi
 WAYLAND_SOCKET=""
 if [ -n "${XDG_RUNTIME_DIR:-}" ] && [ -n "${WAYLAND_DISPLAY:-}" ] \
   && [ -S "$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" ]; then
@@ -541,7 +545,7 @@ env \
   DEV_SANDBOX_INTERACTIVE="$INTERACTIVE" \
   DEV_SANDBOX_USER="$SANDBOX_USER" \
   DEV_SANDBOX_HOME="$SANDBOX_HOME" \
-  DEV_SANDBOX_NODE_DIR="$NODE_DIR" \
+  DEV_SANDBOX_GLOBAL_PROXY_ENV="$DEV_SANDBOX_GLOBAL_PROXY_ENV" \
   DEV_SANDBOX_ELECTRON_LD_LIBRARY_PATH="${DEV_SANDBOX_ELECTRON_LD_LIBRARY_PATH:-}" \
   DEV_SANDBOX_XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-}" \
   DEV_SANDBOX_WAYLAND_DISPLAY="${WAYLAND_DISPLAY:-}" \

--- a/scripts/sandbox/stage2-run.sh
+++ b/scripts/sandbox/stage2-run.sh
@@ -22,6 +22,7 @@ set -euo pipefail
 : "${DEV_SANDBOX_INTERACTIVE:?missing DEV_SANDBOX_INTERACTIVE}"
 : "${DEV_SANDBOX_USER:?missing DEV_SANDBOX_USER}"
 : "${DEV_SANDBOX_HOME:?missing DEV_SANDBOX_HOME}"
+: "${DEV_SANDBOX_GLOBAL_PROXY_ENV:?missing DEV_SANDBOX_GLOBAL_PROXY_ENV}"
 
 # Announce our pid so stage 1 can point slirp4netns at these namespaces,
 # then hold until it reports the network is up.
@@ -47,10 +48,6 @@ if [ "$home_parent" != / ]; then
 fi
 home_mounts+=(--bind "$DEV_SANDBOX_ROOT/home" "$DEV_SANDBOX_HOME")
 
-node_env=()
-if [ -n "${DEV_SANDBOX_NODE_DIR:-}" ]; then
-  node_env+=(--setenv npm_config_nodedir "$DEV_SANDBOX_NODE_DIR")
-fi
 electron_env=()
 if [ -n "${DEV_SANDBOX_ELECTRON_LD_LIBRARY_PATH:-}" ]; then
   electron_env+=(
@@ -196,8 +193,24 @@ if [ "$DEV_SANDBOX_INTERACTIVE" = true ]; then
   dev_mounts=(--dev /dev)
 fi
 
-# Node connects to the local MITM proxy, so it must trust the sandbox CA.
-# proxy.py alone uses real-ca.pem for its separate outbound TLS connection.
+# Generic fixture tests proxy every HTTP(S) request and trust the sandbox CA.
+# Installer tests proxy only their explicit canonical-URL curl; dependency
+# managers connect directly and therefore trust the runner's real CA bundle.
+trust_ca=/work/certs/ca.pem
+proxy_env=(
+  --setenv HTTP_PROXY http://127.0.0.1:8080
+  --setenv HTTPS_PROXY http://127.0.0.1:8080
+  --setenv ALL_PROXY http://127.0.0.1:8080
+  --setenv NO_PROXY ''
+)
+if [ "$DEV_SANDBOX_GLOBAL_PROXY_ENV" = false ]; then
+  trust_ca=/work/certs/real-ca.pem
+  proxy_env=()
+elif [ "$DEV_SANDBOX_GLOBAL_PROXY_ENV" != true ]; then
+  echo "error: invalid DEV_SANDBOX_GLOBAL_PROXY_ENV: $DEV_SANDBOX_GLOBAL_PROXY_ENV" >&2
+  exit 1
+fi
+
 exec bwrap \
   --unshare-pid \
   --die-with-parent --proc /proc --tmpfs /tmp \
@@ -215,18 +228,14 @@ exec bwrap \
   --setenv HOME "$DEV_SANDBOX_HOME" \
   --setenv USER "$DEV_SANDBOX_USER" \
   --setenv LOGNAME "$DEV_SANDBOX_USER" \
-  --setenv CURL_CA_BUNDLE /work/certs/ca.pem \
-  --setenv SSL_CERT_FILE /work/certs/ca.pem \
-  --setenv GIT_SSL_CAINFO /work/certs/ca.pem \
-  --setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem \
+  --setenv CURL_CA_BUNDLE "$trust_ca" \
+  --setenv SSL_CERT_FILE "$trust_ca" \
+  --setenv GIT_SSL_CAINFO "$trust_ca" \
+  --setenv NODE_EXTRA_CA_CERTS "$trust_ca" \
   --setenv OPENSSL_CONF /work/certs/openssl.cnf \
-  --setenv HTTP_PROXY http://127.0.0.1:8080 \
-  --setenv HTTPS_PROXY http://127.0.0.1:8080 \
-  --setenv ALL_PROXY http://127.0.0.1:8080 \
-  --setenv NO_PROXY '' \
+  "${proxy_env[@]}" \
   --setenv DEV_SANDBOX_INTERACTIVE "$DEV_SANDBOX_INTERACTIVE" \
   --setenv ELECTRON_DISABLE_SANDBOX 1 \
-  "${node_env[@]}" \
   "${electron_env[@]}" \
   -- "$DEV_SANDBOX_BASH" -ceu '
     python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem >/work/logs/proxy.log 2>&1 &

--- a/tests/downstream/test_ci_contracts.py
+++ b/tests/downstream/test_ci_contracts.py
@@ -10,6 +10,7 @@ WORKFLOW = ROOT / ".github/workflows/fork-cicd.yml"
 SCHEDULED = ROOT / ".github/workflows/windows-full-qualification.yml"
 RELEASE = ROOT / ".github/workflows/windows-release.yml"
 SANDBOX_STAGE2 = ROOT / "scripts/sandbox/stage2-run.sh"
+SANDBOX_STAGE1 = ROOT / "scripts/dev-sandbox.sh"
 CI = ROOT / ".github/workflows/ci.yaml"
 DETECT_ACTION = ROOT / ".github/actions/detect-changes/action.yml"
 
@@ -122,11 +123,19 @@ def test_release_builds_never_implicitly_publish_from_electron_builder() -> None
     assert all("--publish never" in command for command in builder_commands)
 
 
-def test_sandbox_node_trusts_the_local_mitm_ca() -> None:
+def test_sandbox_installer_fixture_does_not_proxy_external_dependencies() -> None:
+    stage1 = SANDBOX_STAGE1.read_text(encoding="utf-8")
     stage2 = SANDBOX_STAGE2.read_text(encoding="utf-8")
 
-    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/ca.pem" in stage2
-    assert "--setenv NODE_EXTRA_CA_CERTS /work/certs/real-ca.pem" not in stage2
+    assert "DEV_SANDBOX_GLOBAL_PROXY_ENV=false" in stage1
+    assert "curl --proxy http://127.0.0.1:8080" in stage1
+    assert "--cacert /work/certs/ca.pem" in stage1
+    assert 'trust_ca=/work/certs/real-ca.pem' in stage2
+    assert 'proxy_env=()' in stage2
+    assert '--setenv NODE_EXTRA_CA_CERTS "$trust_ca"' in stage2
+    assert '"${proxy_env[@]}"' in stage2
+    assert "DEV_SANDBOX_NODE_DIR" not in stage1
+    assert "npm_config_nodedir" not in stage2
     assert "python3 /work/proxy.py /work/http /work/certs /work/certs/real-ca.pem" in stage2
 
 


### PR DESCRIPTION
## Summary

- proxy only the canonical installer fixture fetch
- give npm, uv, PyPI, and Node downloads direct rootless sandbox egress
- preserve the global fixture proxy for generic --http-root tests
- use the runner real CA bundle for direct dependency TLS

## Evidence

- RED: new route contract failed before implementation
- GREEN: 16 focused tests passed at 15ce34438c
- bash syntax checks passed for both edited sandbox scripts
- exact-head hosted Install & Update E2E will be required before merge

## Failure boundary

This is a materially different fourth approach after TLS retry, handshake serialization, keepalive closure, and the reverted raw CONNECT tunnel. It removes external dependency traffic from the handwritten proxy rather than modifying that proxy again.