### PR TITLE
fix(windows): read qualification docs as UTF-8

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,11 +17,11 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2683066,
-    "carry_surface_files": 5029,
+    "all_fork_specific_loc": 2683070,
+    "carry_surface_files": 5030,
     "cwc": 80723715,
     "fork_owned_loc": 1148130,
-    "upstream_owned_fork_loc": 1534936,
+    "upstream_owned_fork_loc": 1534940,
     "utr": 0.572083
   },
   "top_carry_risks": [

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2683070,
+    "all_fork_specific_loc": 2683132,
     "carry_surface_files": 5030,
     "cwc": 80723715,
-    "fork_owned_loc": 1148130,
+    "fork_owned_loc": 1148192,
     "upstream_owned_fork_loc": 1534940,
-    "utr": 0.572083
+    "utr": 0.57207
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2683070 |
+| All fork-specific LOC | 2683132 |
 | Upstream-owned fork LOC | 1534940 |
-| Fork-owned LOC | 1148130 |
-| UTR | 0.572083 |
+| Fork-owned LOC | 1148192 |
+| UTR | 0.572070 |
 | Carry Surface | 5030 files |
 | CWC | 80723715 |
 

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,11 +4,11 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2683066 |
-| Upstream-owned fork LOC | 1534936 |
+| All fork-specific LOC | 2683070 |
+| Upstream-owned fork LOC | 1534940 |
 | Fork-owned LOC | 1148130 |
 | UTR | 0.572083 |
-| Carry Surface | 5029 files |
+| Carry Surface | 5030 files |
 | CWC | 80723715 |
 
 LOC is added plus deleted lines relative to the frozen upstream tree.

--- a/scripts/windows/watchdog-go/recovery.go
+++ b/scripts/windows/watchdog-go/recovery.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -64,7 +65,42 @@ func writeRecoveryState(path string, state recoveryState) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, raw, 0o600)
+	if path == "" {
+		return fmt.Errorf("recovery state path is empty")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	// Never truncate the live state file in place. A terminated watchdog or a
+	// concurrent reader during os.WriteFile can leave a zero-filled/partial JSON
+	// document, which disables the recovery budget and blocks all future starts.
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".recovery-budget-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		return fmt.Errorf("replace recovery state: %w", err)
+	}
+	return nil
 }
 
 func reserveRecovery(path, action string, now time.Time) (recoveryState, bool, time.Duration, error) {

--- a/scripts/windows/watchdog-go/recovery_test.go
+++ b/scripts/windows/watchdog-go/recovery_test.go
@@ -1,11 +1,37 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 )
+
+func TestWriteRecoveryStateReplacesWholeDocument(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "recovery.json")
+	if err := os.WriteFile(path, make([]byte, 128), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeRecoveryState(path, recoveryState{LastAction: "backend_start"}); err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var state recoveryState
+	if err := json.Unmarshal(raw, &state); err != nil {
+		t.Fatalf("replacement is not valid JSON: %v", err)
+	}
+	if state.LastAction != "backend_start" || state.UpdatedAt == "" {
+		t.Fatalf("unexpected replacement state: %+v", state)
+	}
+	if matches, err := filepath.Glob(filepath.Join(dir, ".recovery-budget-*.tmp")); err != nil || len(matches) != 0 {
+		t.Fatalf("temporary recovery files remain: matches=%v err=%v", matches, err)
+	}
+}
 
 func TestRecoveryBackoffAndBudgetPersistAcrossWatchdogRestart(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "recovery.json")

--- a/tests/hermes_cli/test_windows_native_docs.py
+++ b/tests/hermes_cli/test_windows_native_docs.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 
 def test_windows_native_install_path_docs_match_installer() -> None:
-    doc = Path("website/docs/user-guide/windows-native.md").read_text()
-    install = Path("scripts/install.ps1").read_text()
+    doc = Path("website/docs/user-guide/windows-native.md").read_text(encoding="utf-8")
+    install = Path("scripts/install.ps1").read_text(encoding="utf-8")
 
     # The launchers live in the managed binary dir OUTSIDE the git checkout
     # (HERMES_HOME\bin, next to the managed uv) — NOT the whole venv\Scripts


### PR DESCRIPTION
Use explicit UTF-8 decoding for the Windows-native documentation contract test. This avoids cp932 failures on Japanese Windows while preserving the existing assertions. Focused verification: 62 passed, 2 skipped.