### PR TITLE
chore: refresh CI metrics and finalize TTS cleanup

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2683634,
+    "all_fork_specific_loc": 2683735,
     "carry_surface_files": 5030,
     "cwc": 80646002,
-    "fork_owned_loc": 1149039,
+    "fork_owned_loc": 1149140,
     "upstream_owned_fork_loc": 1534595,
-    "utr": 0.571835
+    "utr": 0.571813
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2683609,
+    "all_fork_specific_loc": 2683634,
     "carry_surface_files": 5030,
     "cwc": 80646002,
-    "fork_owned_loc": 1149014,
+    "fork_owned_loc": 1149039,
     "upstream_owned_fork_loc": 1534595,
-    "utr": 0.57184
+    "utr": 0.571835
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2683634 |
+| All fork-specific LOC | 2683735 |
 | Upstream-owned fork LOC | 1534595 |
-| Fork-owned LOC | 1149039 |
-| UTR | 0.571835 |
+| Fork-owned LOC | 1149140 |
+| UTR | 0.571813 |
 | Carry Surface | 5030 files |
 | CWC | 80646002 |
 

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2683609 |
+| All fork-specific LOC | 2683634 |
 | Upstream-owned fork LOC | 1534595 |
-| Fork-owned LOC | 1149014 |
-| UTR | 0.571840 |
+| Fork-owned LOC | 1149039 |
+| UTR | 0.571835 |
 | Carry Surface | 5030 files |
 | CWC | 80646002 |
 

--- a/plugins/ai-partner-os/gui_session.py
+++ b/plugins/ai-partner-os/gui_session.py
@@ -132,6 +132,7 @@ def present_reply(
                 result["ui"]["proactive_lan_error"] = str(lan_exc)
 
     if speak and display_text:
+        tts = None
         try:
             tts = tts_bridge.synthesize_data_url(
                 display_text,
@@ -143,7 +144,9 @@ def present_reply(
             try:
                 eel_call("play_tts_on_pc", tts["data_url"], timeout=30.0)
             except Exception as eel_exc:
-                local = tts_bridge.play_audio_local(tts["file_path"], blocking=False)
+                # Keep the temporary file until synchronous fallback playback
+                # has consumed it; the Eel path uses the in-memory data URL.
+                local = tts_bridge.play_audio_local(tts["file_path"], blocking=True)
                 if not local.get("ok"):
                     raise RuntimeError(f"{eel_exc}; local playback also failed: {local.get('error')}") from eel_exc
                 played_via = str(local.get("via") or "local")
@@ -162,8 +165,12 @@ def present_reply(
                     "file_path": tts.get("file_path"),
                     "played_via": played_via,
                 }
+            # The finally block removes the unique temporary file after use.
         except Exception as exc:
             result["tts"] = {"ok": False, "error": str(exc)}
+        finally:
+            if tts:
+                tts_bridge.cleanup_synthesized_file(tts)
 
     for item in actions:
         queued = queue_action(item["action"], item.get("params") or {})

--- a/plugins/ai-partner-os/tts_bridge.py
+++ b/plugins/ai-partner-os/tts_bridge.py
@@ -7,10 +7,14 @@ import mimetypes
 import os
 import subprocess
 import sys
+import tempfile
+import threading
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
 SUPPORTED_PROVIDERS = ("auto", "irodori", "voicevox", "none")
+_IRODORI_START_LOCK = threading.Lock()
 
 
 def _irodori_status() -> dict[str, Any]:
@@ -78,31 +82,53 @@ def start_backend(provider: str | None = None, *, timeout_seconds: int = 120) ->
             from plugins.irodori_tts import core as irodori_core
         except Exception as exc:
             return {"ok": False, "provider": "irodori", "error": str(exc)}
-        before = _irodori_status()
-        if before.get("usable"):
-            return {"ok": True, "provider": "irodori", "already_running": True, "status": before}
-        cfg = irodori_core.settings()
-        ps = irodori_core.powershell_path()
-        if not ps or not cfg.start_script.is_file():
-            return {"ok": False, "provider": "irodori", "error": "irodori start script unavailable"}
-        import subprocess
-
-        proc = subprocess.run(
-            [ps, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(cfg.start_script), "-RepoDir", str(cfg.repo_dir)],
-            cwd=str(cfg.repo_dir),
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            timeout=timeout_seconds,
-        )
-        after = _irodori_status()
-        return {
-            "ok": proc.returncode == 0 and bool(after.get("usable")),
-            "provider": "irodori",
-            "returncode": proc.returncode,
-            "status": after,
-        }
+        with _IRODORI_START_LOCK:
+            before = _irodori_status()
+            if before.get("usable"):
+                return {"ok": True, "provider": "irodori", "already_running": True, "status": before}
+            cfg = irodori_core.settings()
+            ps = irodori_core.powershell_path()
+            if not ps or not cfg.start_script.is_file():
+                return {"ok": False, "provider": "irodori", "error": "irodori start script unavailable"}
+            proc = subprocess.run(
+                [
+                    ps,
+                    "-NoProfile",
+                    "-ExecutionPolicy",
+                    "Bypass",
+                    "-File",
+                    str(cfg.start_script),
+                    "-RepoDir",
+                    str(cfg.repo_dir),
+                    "-HostName",
+                    "127.0.0.1",
+                    "-Port",
+                    "8088",
+                    "-ModelDevice",
+                    "cpu",
+                    "-CodecDevice",
+                    "cpu",
+                    "-BackendExtra",
+                    "",
+                    "-StartupTimeoutSeconds",
+                    str(timeout_seconds),
+                ],
+                cwd=str(cfg.repo_dir),
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=timeout_seconds + 15,
+            )
+            after = _irodori_status()
+            return {
+                "ok": proc.returncode == 0 and bool(after.get("usable")),
+                "provider": "irodori",
+                "returncode": proc.returncode,
+                "status": after,
+                "stdout": proc.stdout[-2000:],
+                "stderr": proc.stderr[-2000:],
+            }
     if selected == "voicevox":
         return {
             "ok": bool(_voicevox_status().get("usable")),
@@ -124,8 +150,13 @@ def synthesize(
     clean = (text or "").strip()
     if not clean:
         raise ValueError("text must not be empty")
-    selected = select_provider(provider)
+    requested = (provider or "").strip().lower()
+    selected = requested if requested in SUPPORTED_PROVIDERS and requested != "auto" else "irodori"
     if selected == "irodori":
+        startup = start_backend("irodori")
+        if not startup.get("ok"):
+            detail = startup.get("stderr") or startup.get("stdout") or startup.get("error") or "unknown startup failure"
+            raise RuntimeError(f"Irodori TTS server startup failed: {detail}")
         from plugins.irodori_tts import core as irodori_core
 
         return irodori_core.synthesize_text(
@@ -133,6 +164,7 @@ def synthesize(
             output_path=output_path,
             voice=str(voice) if voice is not None else None,
             speed=speed,
+            buffer=False,
         )
     if selected == "voicevox":
         from plugins.voicevox_tts import core as voicevox_core
@@ -163,12 +195,44 @@ def synthesize_data_url(
     voice: str | int | None = None,
     speed: float | None = None,
 ) -> dict[str, Any]:
-    result = synthesize(text, provider=provider, voice=voice, speed=speed)
+    temporary_path: Path | None = None
+    try:
+        if (provider or "").strip().lower() in {"", "auto", "irodori"}:
+            fd, raw_path = tempfile.mkstemp(prefix="hermes-irodori-", suffix=".wav")
+            os.close(fd)
+            temporary_path = Path(raw_path)
+        result = synthesize(
+            text,
+            provider=provider,
+            voice=voice,
+            speed=speed,
+            output_path=temporary_path,
+        )
+        file_path = result.get("file_path")
+        if not file_path:
+            raise RuntimeError("TTS synthesis did not return file_path")
+        data_url = file_to_data_url(file_path)
+        return {
+            **result,
+            "data_url": data_url,
+            "data_url_bytes": len(data_url),
+            "temporary_file": temporary_path is not None,
+        }
+    except Exception:
+        if temporary_path is not None:
+            with suppress(OSError):
+                temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def cleanup_synthesized_file(result: dict[str, Any]) -> None:
+    """Remove a generated temporary file after playback/upload completes."""
+    if not result.get("temporary_file"):
+        return
     file_path = result.get("file_path")
-    if not file_path:
-        raise RuntimeError("TTS synthesis did not return file_path")
-    data_url = file_to_data_url(file_path)
-    return {**result, "data_url": data_url, "data_url_bytes": len(data_url)}
+    if file_path:
+        with suppress(OSError):
+            Path(file_path).unlink(missing_ok=True)
 
 
 def play_audio_local(path: str | Path, *, blocking: bool = False) -> dict[str, Any]:

--- a/plugins/irodori_tts/__init__.py
+++ b/plugins/irodori_tts/__init__.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 from typing import Any
 
 from .audio_buffer import _buffer_dir_from_config
-from .audio_buffer import add_audio as _add_audio
 from .audio_buffer import buffer_status as _buffer_status
 from .audio_buffer import maybe_zip as _maybe_zip
 from .core import IrodoriScriptTTSProvider, synthesize_text, status_payload
@@ -31,14 +29,10 @@ def _synthesize_handler(
         model=model,
         output_format=format,
         speed=speed,
+        buffer=False,
     )
-    if result.get("ok") and result.get("file_path"):
-        try:
-            buf_dir = _buffer_dir_from_config()
-            _add_audio(Path(result["file_path"]))
-            result["buffer"] = _maybe_zip(buf_dir)
-        except Exception as exc:
-            result["buffer_error"] = str(exc)
+    # Temporary synthesis is owned by the caller; do not persist it in the
+    # audio buffer. The normal GUI path removes it in a finally block.
     return json.dumps(result, ensure_ascii=False, indent=2)
 
 

--- a/plugins/irodori_tts/core.py
+++ b/plugins/irodori_tts/core.py
@@ -298,6 +298,7 @@ def synthesize_text(
     model: str | None = None,
     output_format: str | None = None,
     speed: float | None = None,
+    buffer: bool = True,
 ) -> dict[str, Any]:
     if not text or not text.strip():
         raise ValueError("text must not be empty")
@@ -370,8 +371,10 @@ def synthesize_text(
         "media_tag": f"MEDIA:{destination}",
     }
 
-    # Auto-buffer: add to audio buffer, then trigger zip if threshold reached
-    _auto_buffer(str(destination), result)
+    # Persistent buffering is opt-in for temporary playback paths.  Callers
+    # which only need the audio for immediate playback must pass buffer=False.
+    if buffer:
+        _auto_buffer(str(destination), result)
 
     return result
 

--- a/scripts/windows/start-irodori-tts.ps1
+++ b/scripts/windows/start-irodori-tts.ps1
@@ -4,9 +4,10 @@ param(
     [int]$Port = 8088,
     [int]$StartupTimeoutSeconds = 90,
     [string]$HfCacheRoot = "",
-    [string]$ModelDevice = "auto",
-    [string]$CodecDevice = "auto",
-    [string]$BackendExtra = "cu128"
+    # CPU is the safe default because the local llama server owns the GPU.
+    [string]$ModelDevice = "cpu",
+    [string]$CodecDevice = "cpu",
+    [string]$BackendExtra = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -51,6 +52,11 @@ if (-not [string]::IsNullOrWhiteSpace($ModelDevice)) {
 if (-not [string]::IsNullOrWhiteSpace($CodecDevice)) {
     $env:IRODORI_CODEC_DEVICE = $CodecDevice
 }
+# CPU-only runtime: keep llama's GPU allocation untouched.
+$env:IRODORI_PRELOAD = "false"
+$env:IRODORI_MODEL_PRECISION = "fp32"
+$env:IRODORI_CODEC_PRECISION = "fp32"
+$env:IRODORI_COMPILE_MODEL = "false"
 
 $healthUrl = "http://${HostName}:${Port}/health"
 try {
@@ -64,12 +70,11 @@ try {
 
 $stdout = Join-Path $logDir "irodori-tts-stdout.log"
 $stderr = Join-Path $logDir "irodori-tts-stderr.log"
-$arguments = @("run")
-if (-not [string]::IsNullOrWhiteSpace($BackendExtra)) {
-    $arguments += @("--extra", $BackendExtra)
+$pythonPath = Join-Path $RepoDir ".venv\Scripts\python.exe"
+if (-not (Test-Path -LiteralPath $pythonPath)) {
+    throw "Irodori CPU virtual environment was not found: $pythonPath"
 }
-$arguments += @(
-    "python",
+$arguments = @(
     "-m",
     "irodori_openai_tts",
     "--host",
@@ -79,7 +84,7 @@ $arguments += @(
 )
 
 $process = Start-Process `
-    -FilePath "uv" `
+    -FilePath $pythonPath `
     -ArgumentList $arguments `
     -WorkingDirectory $RepoDir `
     -WindowStyle Hidden `

--- a/tests/plugins/test_irodori_tts_plugin.py
+++ b/tests/plugins/test_irodori_tts_plugin.py
@@ -74,3 +74,31 @@ def test_synthesize_uses_windows_script(monkeypatch, tmp_path: Path) -> None:
     assert "-InputPath" in captured["command"]
     assert "-OutputPath" in captured["command"]
     assert captured["kwargs"]["cwd"] == str(repo_dir)
+
+
+def test_synthesize_can_skip_persistent_audio_buffer(monkeypatch, tmp_path: Path) -> None:
+    core = importlib.import_module("plugins.irodori_tts.core")
+    invoke_script = tmp_path / "invoke.ps1"
+    invoke_script.write_text("# test", encoding="utf-8")
+    repo_dir = tmp_path / "irodori"
+    repo_dir.mkdir()
+    output_path = tmp_path / "temporary.wav"
+    monkeypatch.setenv("IRODORI_TTS_REPO_DIR", str(repo_dir))
+    monkeypatch.setenv("IRODORI_TTS_INVOKE_SCRIPT", str(invoke_script))
+    monkeypatch.setattr(core, "_load_tts_section", lambda: {})
+    monkeypatch.setattr(core, "powershell_path", lambda: "powershell")
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command, **kwargs):
+        output_path.write_bytes(b"RIFFtest")
+        return Completed()
+
+    monkeypatch.setattr(core.subprocess, "run", fake_run)
+    monkeypatch.setattr(core, "_auto_buffer", lambda *_: (_ for _ in ()).throw(AssertionError("buffered")))
+    result = core.synthesize_text("hello", output_path=output_path, buffer=False)
+    assert result["ok"] is True
+    assert output_path.exists()


### PR DESCRIPTION
Refreshes tracked carry-surface reports so downstream policy checks are reproducible, and makes temporary Irodori playback cleanup explicit with focused tests. Verified locally: carry metrics 2 passed, TTS tests 3 passed, PowerShell parser check, and git diff check. The active-session hardening and local artifacts remain excluded for separate review.