### PR TITLE
fix(windows): keep Go watchdog out of Session 0 Desktop kill path

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2709949,
+    "all_fork_specific_loc": 2710007,
     "carry_surface_files": 5075,
     "cwc": 86068502,
-    "fork_owned_loc": 1164344,
+    "fork_owned_loc": 1164402,
     "upstream_owned_fork_loc": 1545605,
-    "utr": 0.570345
+    "utr": 0.570332
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2709593,
+    "all_fork_specific_loc": 2709949,
     "carry_surface_files": 5075,
     "cwc": 86068502,
-    "fork_owned_loc": 1163988,
+    "fork_owned_loc": 1164344,
     "upstream_owned_fork_loc": 1545605,
-    "utr": 0.57042
+    "utr": 0.570345
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2709593 |
+| All fork-specific LOC | 2709949 |
 | Upstream-owned fork LOC | 1545605 |
-| Fork-owned LOC | 1163988 |
-| UTR | 0.570420 |
+| Fork-owned LOC | 1164344 |
+| UTR | 0.570345 |
 | Carry Surface | 5075 files |
 | CWC | 86068502 |
 

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2709949 |
+| All fork-specific LOC | 2710007 |
 | Upstream-owned fork LOC | 1545605 |
-| Fork-owned LOC | 1164344 |
-| UTR | 0.570345 |
+| Fork-owned LOC | 1164402 |
+| UTR | 0.570332 |
 | Carry Surface | 5075 files |
 | CWC | 86068502 |
 

--- a/scripts/windows/Recover-HermesGoWatchdogSession0.ps1
+++ b/scripts/windows/Recover-HermesGoWatchdogSession0.ps1
@@ -1,0 +1,134 @@
+# Operator recovery: displace Session 0 Go watchdog into the interactive session.
+$ErrorActionPreference = "Stop"
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$log = Join-Path $env:TEMP "hermes-watchdog-session0-recover.log"
+$go = Join-Path $root "scripts\windows\Start-HermesGoWatchdog.ps1"
+if (-not [string]::IsNullOrWhiteSpace($env:HERMES_HOME)) {
+    $HermesHome = $env:HERMES_HOME
+} else {
+    $HermesHome = Join-Path $env:USERPROFILE ".hermes"
+}
+$data = Join-Path $env:LOCALAPPDATA "HermesWatchdog"
+
+function Test-IsElevatedOperator {
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } catch {
+        return $false
+    }
+}
+
+if (-not (Test-IsElevatedOperator)) {
+    Write-Host "Not elevated; re-launching with UAC (click Yes)..."
+    $argList = @(
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "`"$PSCommandPath`""
+    )
+    $proc = Start-Process -FilePath "powershell.exe" -ArgumentList $argList -Verb RunAs -Wait -PassThru
+    exit $proc.ExitCode
+}
+
+function Write-Recover([string]$Message) {
+    $line = "[{0}] {1}" -f (Get-Date -Format o), $Message
+    Add-Content -LiteralPath $log -Value $line
+    Write-Host $line
+}
+
+Remove-Item -LiteralPath $log -Force -ErrorAction SilentlyContinue
+Write-Recover ("session={0} elevated={1}" -f (Get-Process -Id $PID).SessionId, ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator))
+
+$budget = Join-Path $data "recovery-budget.json"
+if (Test-Path -LiteralPath $budget) {
+    Copy-Item -LiteralPath $budget -Destination ("{0}.bak-{1}" -f $budget, (Get-Date -Format yyyyMMddHHmmss)) -Force
+    Remove-Item -LiteralPath $budget -Force
+    Write-Recover "cleared recovery-budget.json"
+}
+
+$user = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+$settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -StartWhenAvailable -MultipleInstances IgnoreNew -ExecutionTimeLimit ([TimeSpan]::Zero)
+
+# One-shot S4U stopper: same session class as the boot-time owner, so Terminate works.
+$stopCmd = "`$env:HERMES_HOME='$HermesHome'; & '$go' -Stop -HermesRoot '$root' -HermesHome '$HermesHome'"
+$stopAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command $stopCmd" -WorkingDirectory $root
+$stopPrincipal = New-ScheduledTaskPrincipal -UserId $user -LogonType S4U -RunLevel Highest
+Register-ScheduledTask -TaskName "HermesGoWatchdogSession0StopOnce" -Action $stopAction -Principal $stopPrincipal -Settings $settings -Description "One-shot S4U stop for Session 0 Go watchdog displace" -Force | Out-Null
+Write-Recover "registered HermesGoWatchdogSession0StopOnce"
+Start-ScheduledTask -TaskName "HermesGoWatchdogSession0StopOnce"
+Start-Sleep -Seconds 5
+$stopInfo = Get-ScheduledTaskInfo -TaskName "HermesGoWatchdogSession0StopOnce"
+Write-Recover ("S4U stop result={0}" -f $stopInfo.LastTaskResult)
+
+$alive = Get-Process -Name "hermes-watchdog" -ErrorAction SilentlyContinue
+if ($alive) {
+    Write-Recover ("watchdog still alive pid={0} session={1}; trying elevated Stop-Process" -f $alive.Id, $alive.SessionId)
+    Stop-Process -Id $alive.Id -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 2
+}
+$alive = Get-Process -Name "hermes-watchdog" -ErrorAction SilentlyContinue
+if ($alive) {
+    Write-Recover ("RECOVER_FAIL: watchdog still alive pid={0}" -f $alive.Id)
+    exit 1
+}
+Write-Recover "Session 0 watchdog stopped"
+
+$lock = Join-Path $data "watchdog.lock"
+if (Test-Path -LiteralPath $lock) {
+    Remove-Item -LiteralPath $lock -Force -ErrorAction SilentlyContinue
+    Write-Recover "removed stale lock"
+}
+
+$logonCmd = "`$env:HERMES_HOME='$HermesHome'; & '$go' -HermesRoot '$root' -HermesHome '$HermesHome' -ManagedBackendPort 9119"
+$logonAction = New-ScheduledTaskAction -Execute "powershell.exe" -Argument "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command $logonCmd" -WorkingDirectory $root
+$logonTrigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+$logonTrigger.Delay = "PT20S"
+$logonPrincipal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Highest
+Register-ScheduledTask -TaskName "HermesGoWatchdogLogonAutoStart" -Action $logonAction -Trigger $logonTrigger -Principal $logonPrincipal -Settings $settings -Description "Logon displace Session 0 Go watchdog into the interactive desktop session" -Force | Out-Null
+
+& $go -HermesRoot $root -HermesHome $HermesHome -ManagedBackendPort 9119
+Start-Sleep -Seconds 4
+$wd = Get-Process -Name "hermes-watchdog" -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $wd) {
+    Write-Recover "RECOVER_FAIL: interactive watchdog did not start"
+    exit 1
+}
+Write-Recover ("watchdog pid={0} session={1}" -f $wd.Id, $wd.SessionId)
+if ([int]$wd.SessionId -eq 0) {
+    Write-Recover "RECOVER_FAIL: watchdog still Session 0"
+    exit 1
+}
+
+if (-not (Get-Process -Name "Hermes" -ErrorAction SilentlyContinue)) {
+    Start-ScheduledTask -TaskName "HermesDesktopAutoStart"
+    Start-Sleep -Seconds 8
+}
+$desk = @(Get-Process -Name "Hermes" -ErrorAction SilentlyContinue)
+Write-Recover ("desktop count={0}" -f $desk.Count)
+
+$maint = Join-Path $data "maintenance.json"
+if (Test-Path -LiteralPath $maint) {
+    $now = Get-Date
+    $cleared = @{
+        schemaVersion = 1
+        state = "NORMAL"
+        owner = "hermes-operator-session0-displace"
+        nonce = ([guid]::NewGuid().ToString("N"))
+        epoch = [int64]([DateTimeOffset]$now.ToUniversalTime()).ToUnixTimeMilliseconds() * 1000
+        timestamp = $now.ToUniversalTime().ToString("o")
+        reason = "Session 0 displace completed; resume watchdog supervision"
+        leaseSeconds = 0
+        leaseExpiresAt = $now.ToUniversalTime().ToString("o")
+        pid = $PID
+        processStartTime = $null
+        repoRoot = $root
+    }
+    $json = ($cleared | ConvertTo-Json -Depth 5) + "`n"
+    [System.IO.File]::WriteAllText($maint, $json, [System.Text.UTF8Encoding]::new($false))
+    Write-Recover "cleared OPERATOR_SESSION0_DISPLACE maintenance fence"
+}
+
+Unregister-ScheduledTask -TaskName "HermesGoWatchdogSession0StopOnce" -Confirm:$false -ErrorAction SilentlyContinue
+Write-Recover "RECOVER_OK"
+exit 0

--- a/scripts/windows/Start-HermesGoWatchdog.ps1
+++ b/scripts/windows/Start-HermesGoWatchdog.ps1
@@ -181,6 +181,28 @@ function Get-GoWatchdogLockState {
     }
     $identity = Get-WindowsProcessIdentity -ProcessId $pidLock
     if (-not $identity) {
+        # Session 0 S4U owners often deny PROCESS_QUERY_LIMITED_INFORMATION to an
+        # Interactive launcher. If Get-Process still sees the PID and the lock
+        # names our packaged exe + repo, treat it as owned so stop/displace works.
+        $visible = Get-Process -Id $pidLock -ErrorAction SilentlyContinue
+        if (
+            $visible -and
+            $obj.executablePath -and
+            (Test-SamePath ([string]$obj.executablePath) $Exe) -and
+            (Test-SamePath ([string]$obj.repoRoot) $RepoRoot)
+        ) {
+            $created = 0UL
+            try { $created = [uint64]$obj.processCreated } catch { $created = 0UL }
+            return [pscustomobject]@{
+                Status = "owned"
+                Pid = $pidLock
+                ProcessCreated = $created
+                ExecutablePath = Get-NormalizedPath ([string]$obj.executablePath)
+                RepoRoot = Get-NormalizedPath ([string]$obj.repoRoot)
+                SessionId = [int]$visible.SessionId
+                Reason = "lock matched visible process without OpenProcess query"
+            }
+        }
         return [pscustomobject]@{ Status = "stale"; Pid = $pidLock; Reason = "process is absent" }
     }
     if (-not (Test-SamePath ([string]$obj.repoRoot) $RepoRoot)) {
@@ -203,12 +225,15 @@ function Get-GoWatchdogLockState {
     if (-not $creationMatches) {
         return [pscustomobject]@{ Status = "foreign"; Pid = $pidLock; Reason = "process creation time mismatch" }
     }
+    $sessionId = -1
+    try { $sessionId = [int](Get-Process -Id $pidLock -ErrorAction Stop).SessionId } catch { $sessionId = -1 }
     return [pscustomobject]@{
         Status = "owned"
         Pid = $pidLock
         ProcessCreated = [uint64]$identity.ProcessCreated
         ExecutablePath = $identity.ExecutablePath
         RepoRoot = Get-NormalizedPath ([string]$obj.repoRoot)
+        SessionId = $sessionId
         Reason = "full identity matched"
     }
 }
@@ -224,27 +249,80 @@ function Stop-GoWatchdog {
         $access = 0x1000 -bor 0x0001 -bor 0x00100000
         $handle = [HermesWatchdog.NativeProcess]::OpenProcess($access, $false, [uint32]$state.Pid)
         if ($handle -eq [IntPtr]::Zero) {
-            Write-Warning "Could not open the validated watchdog process; preserving its lock."
-            return $false
-        }
-        try {
-            $current = Get-WindowsProcessIdentityFromHandle -Handle $handle -ProcessId $state.Pid
+            # S4U Session 0 owners often deny TERMINATE (and sometimes image-name
+            # query) even to an elevated Interactive launcher. Re-validate with
+            # QUERY_LIMITED only, then Stop-Process to displace the boot owner.
+            $queryHandle = [HermesWatchdog.NativeProcess]::OpenProcess(0x1000, $false, [uint32]$state.Pid)
+            $queryOk = $false
+            try {
+                if ($queryHandle -ne [IntPtr]::Zero) {
+                    $current = Get-WindowsProcessIdentityFromHandle -Handle $queryHandle -ProcessId $state.Pid
+                    $queryOk = (
+                        $current -and
+                        [uint64]$current.ProcessCreated -eq [uint64]$state.ProcessCreated -and
+                        (
+                            -not $current.ExecutablePath -or
+                            (Test-SamePath $current.ExecutablePath $state.ExecutablePath)
+                        ) -and
+                        (Test-SamePath $state.RepoRoot $RepoRoot)
+                    )
+                }
+            } finally {
+                if ($queryHandle -ne [IntPtr]::Zero) {
+                    [void][HermesWatchdog.NativeProcess]::CloseHandle($queryHandle)
+                }
+            }
+            $alive = $null -ne (Get-Process -Id ([int]$state.Pid) -ErrorAction SilentlyContinue)
+            $sessionId = -1
+            try { $sessionId = [int](Get-Process -Id ([int]$state.Pid) -ErrorAction Stop).SessionId } catch {}
             if (
-                -not $current -or
-                [uint64]$current.ProcessCreated -ne [uint64]$state.ProcessCreated -or
-                -not (Test-SamePath $current.ExecutablePath $state.ExecutablePath) -or
-                -not (Test-SamePath $state.RepoRoot $RepoRoot)
+                $alive -and
+                (
+                    $queryOk -or
+                    (
+                        $sessionId -eq 0 -and
+                        (Test-SamePath $state.ExecutablePath $Exe) -and
+                        (Test-SamePath $state.RepoRoot $RepoRoot)
+                    )
+                )
             ) {
-                Write-Warning "Watchdog identity changed before stop; preserving its lock."
+                Write-Warning ("OpenProcess terminate denied for pid={0} session={1}; falling back to Stop-Process." -f $state.Pid, $sessionId)
+                try {
+                    Stop-Process -Id ([int]$state.Pid) -Force -ErrorAction Stop
+                    Start-Sleep -Milliseconds 800
+                } catch {
+                    Write-Warning "Stop-Process fallback failed: $($_.Exception.Message); trying taskkill."
+                    $tk = Start-Process -FilePath "$env:SystemRoot\System32\taskkill.exe" -ArgumentList @("/F","/PID","$($state.Pid)") -Wait -PassThru -WindowStyle Hidden
+                    if ($tk.ExitCode -notin 0, 128) {
+                        Write-Warning "taskkill fallback failed (exit $($tk.ExitCode)); preserving its lock."
+                        return $false
+                    }
+                    Start-Sleep -Milliseconds 800
+                }
+            } else {
+                Write-Warning "Could not open the validated watchdog process; preserving its lock."
                 return $false
             }
-            if (-not [HermesWatchdog.NativeProcess]::TerminateProcess($handle, 1)) {
-                Write-Warning "Exact watchdog process handle could not be terminated; preserving its lock."
-                return $false
+        } else {
+            try {
+                $current = Get-WindowsProcessIdentityFromHandle -Handle $handle -ProcessId $state.Pid
+                if (
+                    -not $current -or
+                    [uint64]$current.ProcessCreated -ne [uint64]$state.ProcessCreated -or
+                    -not (Test-SamePath $current.ExecutablePath $state.ExecutablePath) -or
+                    -not (Test-SamePath $state.RepoRoot $RepoRoot)
+                ) {
+                    Write-Warning "Watchdog identity changed before stop; preserving its lock."
+                    return $false
+                }
+                if (-not [HermesWatchdog.NativeProcess]::TerminateProcess($handle, 1)) {
+                    Write-Warning "Exact watchdog process handle could not be terminated; preserving its lock."
+                    return $false
+                }
+                [void][HermesWatchdog.NativeProcess]::WaitForSingleObject($handle, 2000)
+            } finally {
+                [void][HermesWatchdog.NativeProcess]::CloseHandle($handle)
             }
-            [void][HermesWatchdog.NativeProcess]::WaitForSingleObject($handle, 2000)
-        } finally {
-            [void][HermesWatchdog.NativeProcess]::CloseHandle($handle)
         }
         $state = Get-GoWatchdogLockState
     }
@@ -252,6 +330,9 @@ function Stop-GoWatchdog {
         Remove-Item -LiteralPath $LockPath -Force -ErrorAction Stop
     } elseif ($state.Status -eq "foreign") {
         Write-Warning "Go watchdog lock identity is foreign ($($state.Reason)); refusing to stop or remove its lock."
+        return $false
+    } elseif ($state.Status -eq "owned") {
+        Write-Warning "Go watchdog still owned after stop attempt; preserving its lock."
         return $false
     }
     return $true
@@ -390,6 +471,47 @@ json.dump(payload, sys.stdout, ensure_ascii=False)
         "-embedding-args-json", $argumentsJson,
         "-embedding-start-timeout=$startTimeout"
     )
+}
+
+function Get-CurrentProcessSessionId {
+    try {
+        return [int](Get-Process -Id $PID -ErrorAction Stop).SessionId
+    } catch {
+        return -1
+    }
+}
+
+function Get-GoWatchdogSessionId {
+    $state = Get-GoWatchdogLockState
+    if ($state.Status -ne "owned" -or -not $state.Pid) {
+        return $null
+    }
+    if ($null -ne $state.PSObject.Properties["SessionId"] -and $null -ne $state.SessionId -and [int]$state.SessionId -ge 0) {
+        return [int]$state.SessionId
+    }
+    try {
+        return [int](Get-Process -Id ([int]$state.Pid) -ErrorAction Stop).SessionId
+    } catch {
+        return $null
+    }
+}
+
+# Boot S4U tasks park hermes-watchdog.exe in Session 0. That owner can kill
+# interactive Hermes.exe but cannot relaunch a visible Desktop, so an
+# Interactive elevated launcher must displace it instead of "already running".
+$launcherSessionId = Get-CurrentProcessSessionId
+$existingWatchdogSessionId = Get-GoWatchdogSessionId
+$replaceSession0Owner = (
+    -not $ForceRestart -and
+    -not $Once -and
+    -not $Stop -and
+    $null -ne $existingWatchdogSessionId -and
+    [int]$existingWatchdogSessionId -eq 0 -and
+    [int]$launcherSessionId -gt 0
+)
+if ($replaceSession0Owner) {
+    Write-Warning ("Replacing Session 0 Go watchdog (pid session={0}) with interactive-session owner (launcher session={1})." -f $existingWatchdogSessionId, $launcherSessionId)
+    $ForceRestart = $true
 }
 
 if ($ForceRestart -or $Once) {

--- a/scripts/windows/Start-HermesGoWatchdog.ps1
+++ b/scripts/windows/Start-HermesGoWatchdog.ps1
@@ -525,6 +525,21 @@ if ($ForceRestart -or $Once) {
     }
 }
 Stop-PsDesktopBackendWatchdog
+
+# Burned recovery budgets survive reboot and suppress Desktop relaunch
+# ("defer until managed backend auth-ok" / desktop_restart cooldown). Interactive
+# logon must start clean so HermesDesktopAutoStart is not undone by a stale
+# circuit from the previous boot flap.
+if ((Get-CurrentProcessSessionId) -gt 0 -and -not $Stop) {
+    $recoveryBudgetPath = Join-Path $DataDir "recovery-budget.json"
+    if (Test-Path -LiteralPath $recoveryBudgetPath) {
+        $stamp = Get-Date -Format "yyyyMMddHHmmss"
+        Copy-Item -LiteralPath $recoveryBudgetPath -Destination ("{0}.bak-logon-{1}" -f $recoveryBudgetPath, $stamp) -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $recoveryBudgetPath -Force -ErrorAction SilentlyContinue
+        Write-Host "Cleared recovery-budget.json for interactive logon start"
+    }
+}
+
 if (Test-GoWatchdogAlive) {
     Write-Host "Go watchdog already running (lock=$LockPath)"
     exit 0

--- a/scripts/windows/repair-hermes-autostart.ps1
+++ b/scripts/windows/repair-hermes-autostart.ps1
@@ -84,7 +84,8 @@ function Register-HermesTask {
         [Parameter(Mandatory = $true)][string]$Command,
         [Parameter(Mandatory = $true)][string]$WorkingDirectory,
         [ValidateSet("Boot", "Logon")][string]$TriggerKind,
-        [int]$DelaySeconds
+        [int]$DelaySeconds,
+        [ValidateSet("Limited", "Highest")][string]$RunLevel = "Limited"
     )
 
     $action = New-ScheduledTaskAction `
@@ -96,7 +97,7 @@ function Register-HermesTask {
         $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType S4U -RunLevel Highest
     } else {
         $trigger = New-ScheduledTaskTrigger -AtLogOn -User $currentUser
-        $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Interactive -RunLevel Limited
+        $principal = New-ScheduledTaskPrincipal -UserId $currentUser -LogonType Interactive -RunLevel $RunLevel
     }
     if ($DelaySeconds -gt 0) {
         $trigger.Delay = "PT${DelaySeconds}S"
@@ -110,7 +111,7 @@ function Register-HermesTask {
         -Settings (New-TaskSettings) `
         -Description $Description `
         -Force | Out-Null
-    Write-Host "Registered $TriggerKind task: $TaskName"
+    Write-Host "Registered $TriggerKind task: $TaskName (RunLevel=$($principal.RunLevel))"
 }
 
 $homeLiteral = Escape-PowerShellLiteral $HermesHome
@@ -127,6 +128,7 @@ $gatewayEnvPrefix = "$envPrefix`$env:HERMES_STARTUP_DELAY_SECONDS='20'; `$env:HE
 
 $taskCommands = @{
     HermesGoWatchdogBootAutoStart = "$envPrefix& '$goLiteral' -HermesRoot '$rootLiteral' -HermesHome '$homeLiteral' -ManagedBackendPort 9119"
+    HermesGoWatchdogLogonAutoStart = "$envPrefix& '$goLiteral' -HermesRoot '$rootLiteral' -HermesHome '$homeLiteral' -ManagedBackendPort 9119"
     HermesGatewayBootAutoStart = "$gatewayEnvPrefix& '$gatewayLiteral'"
     HermesHypuraHarnessBootAutoStart = "$envPrefix& '$pythonLiteral' -m hermes_cli.main harness start"
     HermesMemoryGraphBootAutoStart = "$envPrefix& '$memoryLiteral'"
@@ -137,14 +139,15 @@ $taskCommands = @{
 }
 
 $taskSpecs = @(
-    @{Name = "HermesGoWatchdogBootAutoStart"; Kind = "Boot"; Delay = 15; Description = "Boot auto-start Hermes Go watchdog from the canonical checkout"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesGatewayBootAutoStart"; Kind = "Boot"; Delay = 20; Description = "Boot auto-start Hermes Gateway from the canonical checkout"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesHypuraHarnessBootAutoStart"; Kind = "Boot"; Delay = 40; Description = "Boot auto-start Hypura Harness from the canonical checkout"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesMemoryGraphBootAutoStart"; Kind = "Boot"; Delay = 55; Description = "Boot auto-start Hermes MemoryGraph from the canonical checkout"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesDashboardBootAutoStart"; Kind = "Boot"; Delay = 70; Description = "Boot auto-start Hermes Dashboard from the canonical checkout"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesDesktopAutoStart"; Kind = "Logon"; Delay = 90; Description = "Logon auto-start Hermes Desktop through the canonical launcher"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesDashboardAutoStart"; Kind = "Logon"; Delay = 75; Description = "Logon auto-start Hermes Dashboard from the canonical checkout"; WorkingDirectory = $repoRoot},
-    @{Name = "HermesMemoryGraphAutoStart"; Kind = "Logon"; Delay = 78; Description = "Logon auto-start Hermes MemoryGraph from the canonical checkout"; WorkingDirectory = $repoRoot}
+    @{Name = "HermesGoWatchdogBootAutoStart"; Kind = "Boot"; Delay = 15; RunLevel = "Highest"; Description = "Boot auto-start Hermes Go watchdog from the canonical checkout"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesGoWatchdogLogonAutoStart"; Kind = "Logon"; Delay = 20; RunLevel = "Highest"; Description = "Logon displace Session 0 Go watchdog into the interactive desktop session"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesGatewayBootAutoStart"; Kind = "Boot"; Delay = 20; RunLevel = "Highest"; Description = "Boot auto-start Hermes Gateway from the canonical checkout"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesHypuraHarnessBootAutoStart"; Kind = "Boot"; Delay = 40; RunLevel = "Highest"; Description = "Boot auto-start Hypura Harness from the canonical checkout"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesMemoryGraphBootAutoStart"; Kind = "Boot"; Delay = 55; RunLevel = "Highest"; Description = "Boot auto-start Hermes MemoryGraph from the canonical checkout"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesDashboardBootAutoStart"; Kind = "Boot"; Delay = 70; RunLevel = "Highest"; Description = "Boot auto-start Hermes Dashboard from the canonical checkout"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesDesktopAutoStart"; Kind = "Logon"; Delay = 90; RunLevel = "Limited"; Description = "Logon auto-start Hermes Desktop through the canonical launcher"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesDashboardAutoStart"; Kind = "Logon"; Delay = 75; RunLevel = "Limited"; Description = "Logon auto-start Hermes Dashboard from the canonical checkout"; WorkingDirectory = $repoRoot},
+    @{Name = "HermesMemoryGraphAutoStart"; Kind = "Logon"; Delay = 78; RunLevel = "Limited"; Description = "Logon auto-start Hermes MemoryGraph from the canonical checkout"; WorkingDirectory = $repoRoot}
 )
 
 if (-not $VerifyOnly) {
@@ -155,7 +158,8 @@ if (-not $VerifyOnly) {
             -Command $taskCommands[$spec.Name] `
             -WorkingDirectory $spec.WorkingDirectory `
             -TriggerKind $spec.Kind `
-            -DelaySeconds $spec.Delay
+            -DelaySeconds $spec.Delay `
+            -RunLevel $spec.RunLevel
     }
 }
 

--- a/scripts/windows/restart-hermes-autostart-admin.ps1
+++ b/scripts/windows/restart-hermes-autostart-admin.ps1
@@ -158,7 +158,8 @@ try {
             [Parameter(Mandatory = $true)][string]$Description,
             [Parameter(Mandatory = $true)][string]$PowerShellCommand,
             [Parameter(Mandatory = $true)][string]$WorkingDirectory,
-            [int]$DelaySeconds = 30
+            [int]$DelaySeconds = 30,
+            [ValidateSet("Limited", "Highest")][string]$RunLevel = "Limited"
         )
 
         $actionArgs = "-NoProfile -WindowStyle Hidden -ExecutionPolicy Bypass -Command $PowerShellCommand"
@@ -167,7 +168,7 @@ try {
         if ($DelaySeconds -gt 0) {
             $trigger.Delay = "PT${DelaySeconds}S"
         }
-        $principal = New-ScheduledTaskPrincipal -UserId $CurrentUser -LogonType Interactive -RunLevel Limited
+        $principal = New-ScheduledTaskPrincipal -UserId $CurrentUser -LogonType Interactive -RunLevel $RunLevel
         $settings = New-HermesTaskSettings
 
         Register-ScheduledTask `
@@ -179,7 +180,7 @@ try {
             -Description $Description `
             -Force | Out-Null
 
-        Write-Step "Registered logon task: $TaskName"
+        Write-Step "Registered logon task: $TaskName (RunLevel=$RunLevel)"
     }
 
     $envPrefix = Join-EnvPrefix @{
@@ -202,6 +203,16 @@ try {
         -PowerShellCommand "$envPrefix& '$GoWatchdogScript' -HermesRoot '$RepoRoot' -HermesHome '$HermesHome' -ManagedBackendPort 9119" `
         -WorkingDirectory $RepoRoot `
         -DelaySeconds 15
+
+    # Interactive+Highest logon task displaces the S4U Session 0 boot owner so
+    # Desktop kill/relaunch stays inside the console user's session.
+    Register-HermesLogonTask `
+        -TaskName "HermesGoWatchdogLogonAutoStart" `
+        -Description "Logon displace Session 0 Go watchdog into the interactive desktop session" `
+        -PowerShellCommand "$envPrefix& '$GoWatchdogScript' -HermesRoot '$RepoRoot' -HermesHome '$HermesHome' -ManagedBackendPort 9119" `
+        -WorkingDirectory $RepoRoot `
+        -DelaySeconds 20 `
+        -RunLevel Highest
 
     Register-HermesBootTask `
         -TaskName "HermesGatewayBootAutoStart" `
@@ -324,6 +335,7 @@ try {
 
     Write-Step "Starting Hermes tasks in order..."
     Start-HermesTask -TaskName "HermesGoWatchdogBootAutoStart" -WaitSeconds 4
+    Start-HermesTask -TaskName "HermesGoWatchdogLogonAutoStart" -WaitSeconds 4
     Start-HermesTask -TaskName "HermesGatewayBootAutoStart" -WaitSeconds 12
     Start-HermesTask -TaskName "HermesHypuraHarnessBootAutoStart" -WaitSeconds 6
     Start-HermesTask -TaskName "HermesLineNgrokBootAutoStart" -WaitSeconds 4
@@ -372,6 +384,7 @@ try {
     Write-Step "Verification: boot task triggers"
     foreach ($name in @(
         "HermesGoWatchdogBootAutoStart",
+        "HermesGoWatchdogLogonAutoStart",
         "HermesGatewayBootAutoStart",
         "HermesHypuraHarnessBootAutoStart",
         "HermesLineNgrokBootAutoStart",

--- a/scripts/windows/watchdog-go/README.md
+++ b/scripts/windows/watchdog-go/README.md
@@ -25,10 +25,16 @@ powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\Build-Hermes
 
 通常のワークステーション起動では、管理者が登録した
 `HermesGoWatchdogBootAutoStart` Scheduled Task がブート時に
-`Start-HermesGoWatchdog.ps1` を非表示 PowerShell で実行します。手動操作では、
-管理者 PowerShell から同じ launcher を実行します。どちらも最終的に
-Windows GUI subsystem の `hermes-watchdog.exe` を画面なしで起動し、別の
-Watchdog 起動機構は設けません。
+`Start-HermesGoWatchdog.ps1` を非表示 PowerShell で実行します。S4U ブートは
+Session 0 に落ちるため、続けて `HermesGoWatchdogLogonAutoStart`
+（Interactive + Highest）がログオン後に同一 launcher を実行し、Session 0
+所有者を対話セッションへ置換します。手動操作では、管理者 PowerShell から
+同じ launcher を実行します。どちらも最終的に Windows GUI subsystem の
+`hermes-watchdog.exe` を画面なしで起動し、別の Watchdog 起動機構は設けません。
+
+Session 0 のまま残った watchdog は Desktop を kill できても再表示できないため、
+Go 本体は Session 0 での Desktop 強制停止を拒否し、不在時は
+`HermesDesktopAutoStart` 経由で対話セッションへ起動を依頼します。
 
 ```powershell
 # 環境変数（例）

--- a/scripts/windows/watchdog-go/backend.go
+++ b/scripts/windows/watchdog-go/backend.go
@@ -388,10 +388,53 @@ func (bm *BackendManager) EnsureHealthy() (*backendInfo, error) {
 	// Refuse to publish a token that does not authenticate (squatter race).
 	if !testBackendAuth(port, token) {
 		bm.logger.Infof("managed backend status-ready but auth failed on port %d; refusing drifted manifest", port)
+		reusedToken := preferredToken != "" && token == preferredToken
 		bm.stopLocked()
 		_ = waitManagedPortCleared(port, 15*time.Second, bm.logger)
 		bm.clearManifest()
-		return nil, fmt.Errorf("managed backend on port %d failed session-token auth", port)
+		// Boot/logon often reuses a stale preferred token while serve minted a
+		// different gate. One fresh-token retry avoids burning the recovery
+		// budget and killing interactive Desktop.
+		if reusedToken {
+			bm.logger.Infof("retrying managed serve on port %d with freshly minted session token", port)
+			bm.token = ""
+			cmd2, token2, port2, err2 := buildServeCommand(bm.cfg, "")
+			if err2 != nil {
+				bm.clearManifest()
+				return nil, fmt.Errorf("managed backend on port %d failed session-token auth (fresh mint: %w)", port, err2)
+			}
+			hideWindowsProcess(cmd2)
+			stdout2, err2 := cmd2.StdoutPipe()
+			if err2 != nil {
+				return nil, err2
+			}
+			cmd2.Stderr = io.Discard
+			if err2 := cmd2.Start(); err2 != nil {
+				bm.clearManifest()
+				return nil, err2
+			}
+			bm.cmd = cmd2
+			bm.pid = cmd2.Process.Pid
+			bm.port = port2
+			bm.token = token2
+			go io.Copy(io.Discard, stdout2)
+			if err2 := bm.waitForReadyPort(port2, time.Duration(bm.cfg.BackendStartTimeoutSec)*time.Second); err2 != nil {
+				if err3 := bm.waitForReadyPort(port2, time.Duration(bm.cfg.BackendReadyTimeoutSec)*time.Second); err3 != nil {
+					bm.stopLocked()
+					bm.clearManifest()
+					return nil, fmt.Errorf("managed backend on port %d failed session-token auth (fresh ready: %w)", port, err3)
+				}
+			}
+			if !testBackendAuth(port2, token2) {
+				bm.stopLocked()
+				_ = waitManagedPortCleared(port2, 15*time.Second, bm.logger)
+				bm.clearManifest()
+				return nil, fmt.Errorf("managed backend on port %d failed session-token auth after fresh mint", port2)
+			}
+			port = port2
+		} else {
+			return nil, fmt.Errorf("managed backend on port %d failed session-token auth", port)
+		}
 	}
 
 	if err := bm.publishManifestLocked(port, bm.pid); err != nil {

--- a/scripts/windows/watchdog-go/process_windows.go
+++ b/scripts/windows/watchdog-go/process_windows.go
@@ -445,10 +445,56 @@ func readLaunchManifest(cfg Config, bm *BackendManager) *DesktopBackendManifest 
 	return &manifest
 }
 
+// currentProcessSessionID returns the Windows session that hosts this process.
+// Session 0 is the non-interactive services session (S4U boot tasks land here).
+func currentProcessSessionID() (uint32, error) {
+	var sessionID uint32
+	err := windows.ProcessIdToSessionId(uint32(os.Getpid()), &sessionID)
+	return sessionID, err
+}
+
+func isNonInteractiveSession() bool {
+	sessionID, err := currentProcessSessionID()
+	return err == nil && sessionID == 0
+}
+
+const desktopLogonTaskName = "HermesDesktopAutoStart"
+
+// startDesktopInInteractiveSession asks the logon-registered Desktop task to
+// run in the user's interactive session. Direct CreateProcess from Session 0
+// either fails silently or produces a window the console user never sees.
+func startDesktopInInteractiveSession(logger *Logger) bool {
+	cmd := exec.Command("schtasks.exe", "/Run", "/TN", desktopLogonTaskName)
+	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	out, err := cmd.CombinedOutput()
+	trimmed := strings.TrimSpace(string(out))
+	if err != nil {
+		if logger != nil {
+			logger.Infof("Session 0 Desktop relaunch via %s failed: %v (%s)", desktopLogonTaskName, err, trimmed)
+		}
+		return false
+	}
+	if logger != nil {
+		logger.Infof("requested interactive Desktop launch via scheduled task %s", desktopLogonTaskName)
+	}
+	return true
+}
+
 func startPackagedDesktop(cfg Config, logger *Logger, bm *BackendManager, mutationAllowed func() bool) bool {
 	if !fileExists(cfg.PackagedExe) {
 		logger.Infof("Hermes.exe missing at %s", cfg.PackagedExe)
 		return false
+	}
+	if mutationAllowed != nil && !mutationAllowed() {
+		logger.Infof("Desktop launch revoked by maintenance fence")
+		return false
+	}
+	// S4U boot tasks host the watchdog in Session 0. Never CreateProcess a GUI
+	// Desktop there — kill+skip left the console without Hermes.exe and burned
+	// the recovery budget. Prefer the Interactive logon task instead.
+	if isNonInteractiveSession() {
+		logger.Infof("watchdog is running in Session 0 (non-interactive); launching Desktop via %s (Desktop belongs in user session)", desktopLogonTaskName)
+		return startDesktopInInteractiveSession(logger)
 	}
 	work := filepath.Dir(cfg.PackagedExe)
 	cmd := exec.Command(cfg.PackagedExe)
@@ -456,10 +502,6 @@ func startPackagedDesktop(cfg Config, logger *Logger, bm *BackendManager, mutati
 	manifest := readLaunchManifest(cfg, bm)
 	cmd.Env = append(stripInheritedDesktopRemotes(os.Environ()), desktopLaunchEnv(cfg, manifest)...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	if mutationAllowed != nil && !mutationAllowed() {
-		logger.Infof("Desktop launch revoked by maintenance fence")
-		return false
-	}
 	if err := cmd.Start(); err != nil {
 		logger.Infof("failed to launch Desktop: %v", err)
 		return false
@@ -475,6 +517,17 @@ func startPackagedDesktop(cfg Config, logger *Logger, bm *BackendManager, mutati
 func restartPackagedDesktop(cfg Config, logger *Logger, bm *BackendManager, mutationAllowed func() bool) bool {
 	if mutationAllowed != nil && !mutationAllowed() {
 		logger.Infof("Desktop restart revoked before stop")
+		return false
+	}
+	// Session 0 can terminate interactive Hermes.exe but cannot put a visible
+	// window back. Refusing the stop avoids "Desktop mysteriously dies".
+	if isNonInteractiveSession() {
+		logger.Infof("Session 0: refusing Desktop kill; recovering managed backend only")
+		if bm != nil {
+			if _, err := bm.EnsureHealthy(); err != nil {
+				logger.Infof("Session 0 backend recovery: %v", err)
+			}
+		}
 		return false
 	}
 	logger.Infof("restarting Desktop (force backend respawn)")

--- a/tests/test_go_watchdog_architecture_contract.py
+++ b/tests/test_go_watchdog_architecture_contract.py
@@ -24,6 +24,7 @@ def test_watchdog_uses_the_documented_single_startup_and_probe_defaults() -> Non
     assert 'flag.Int("interval", 20,' in main
     assert 'flag.Int("fail-threshold", 2,' in main
     assert '"HermesGoWatchdogBootAutoStart"' in autostart
+    assert '"HermesGoWatchdogLogonAutoStart"' in autostart
     assert "-WindowStyle Hidden" in autostart
 
 
@@ -45,3 +46,19 @@ def test_a2a_sidecars_are_outside_direct_watchdog_management() -> None:
     assert "9124: {}" in process
     assert "go-a2a-hub" not in process
     assert "go-a2a-roundrobin" not in process
+
+
+def test_session0_watchdog_cannot_orphan_desktop() -> None:
+    """S4U boot owners must not kill interactive Hermes.exe without relaunch."""
+    process = _read(GO / "process_windows.go")
+    launcher = _read(WINDOWS / "Start-HermesGoWatchdog.ps1")
+
+    assert "isNonInteractiveSession" in process
+    assert "Session 0: refusing Desktop kill" in process
+    assert "HermesDesktopAutoStart" in process
+    assert "startDesktopInInteractiveSession" in process
+    assert "Replacing Session 0 Go watchdog" in launcher
+    assert "Get-GoWatchdogSessionId" in launcher
+    assert '$state.Status -ne "owned"' in launcher
+    assert "lock matched visible process without OpenProcess query" in launcher
+    assert "$replaceSession0Owner" in launcher

--- a/tests/test_go_watchdog_task_registration.py
+++ b/tests/test_go_watchdog_task_registration.py
@@ -46,8 +46,16 @@ def test_watchdog_task_registration_matches_the_go_default_backend_port() -> Non
         legacy_start,
         "legacy PowerShell default",
     )
-    registered_default = _single_port(
-        r"-ManagedBackendPort\s+(\d+)", autostart, "scheduled-task port"
+    registered_ports = [
+        int(match)
+        for match in re.findall(r"-ManagedBackendPort\s+(\d+)", autostart)
+    ]
+    assert registered_ports, "scheduled-task port registrations are missing"
+    assert set(registered_ports) == {expected}, (
+        f"scheduled-task ports {registered_ports} must all equal {expected}"
+    )
+    assert len(registered_ports) >= 2, (
+        "boot and logon Go watchdog tasks must both pin the managed port"
     )
     documented_default = _single_port(
         r"\|\s*`-managed-backend-port`\s*\|\s*(\d+)\s*\|",
@@ -58,7 +66,6 @@ def test_watchdog_task_registration_matches_the_go_default_backend_port() -> Non
     assert {
         go_default,
         legacy_default,
-        registered_default,
         documented_default,
     } == {expected}
 


### PR DESCRIPTION
## Summary
- Session 0 Go watchdog must not kill interactive Desktop; relaunch via Desktop scheduled task
- Interactive launcher auto-displaces Session 0 owners; logon autostart pinned Highest
- Operator recovery script + architecture/task-registration contract tests

## Test plan
- [x] `pytest tests/test_go_watchdog_architecture_contract.py tests/test_go_watchdog_task_registration.py`
- [x] `go test ./...` in `scripts/windows/watchdog-go`
- [ ] CI green on this PR / main