### PR TITLE
fix(desktop): clear SCM name-dialog close timer on unmount

### DIFF
--- a/_docs/carry-surface-20260826.json
+++ b/_docs/carry-surface-20260826.json
@@ -17,12 +17,12 @@
   "schema_version": 1,
   "snapshot_sha": "b51c055a12220f8c7c18660e8599365012e19532",
   "summary": {
-    "all_fork_specific_loc": 2710007,
+    "all_fork_specific_loc": 2710057,
     "carry_surface_files": 5075,
     "cwc": 86068502,
-    "fork_owned_loc": 1164402,
+    "fork_owned_loc": 1164452,
     "upstream_owned_fork_loc": 1545605,
-    "utr": 0.570332
+    "utr": 0.570322
   },
   "top_carry_risks": [
     {

--- a/_docs/carry-surface-20260826.md
+++ b/_docs/carry-surface-20260826.md
@@ -4,10 +4,10 @@ Frozen upstream: b51c055a12220f8c7c18660e8599365012e19532
 
 | Metric | Value |
 | --- | ---: |
-| All fork-specific LOC | 2710007 |
+| All fork-specific LOC | 2710057 |
 | Upstream-owned fork LOC | 1545605 |
-| Fork-owned LOC | 1164402 |
-| UTR | 0.570332 |
+| Fork-owned LOC | 1164452 |
+| UTR | 0.570322 |
 | Carry Surface | 5075 files |
 | CWC | 86068502 |
 

--- a/apps/desktop/src/app/right-sidebar/review/scm-rail.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/scm-rail.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesGitBranch, HermesGitStash, HermesGitTag } from '@/global'
@@ -247,6 +247,41 @@ describe('ReviewScmRail', () => {
     fireEvent.click(within(dialog).getByRole('button', { name: 'New tag' }))
 
     await waitFor(() => expect(git.tagCreate).toHaveBeenCalledWith('/repo', 'v2.0', null))
+  })
+
+  it('clears the post-submit close timer when the rail unmounts', async () => {
+    vi.useFakeTimers()
+    try {
+      const clearSpy = vi.spyOn(window, 'clearTimeout')
+      const git = stubGit()
+      const { unmount } = renderRail()
+
+      fireEvent.click(screen.getByRole('button', { name: 'New tag' }))
+      const dialog = screen.getByRole('dialog')
+      fireEvent.change(within(dialog).getByRole('textbox', { name: 'Tag name' }), {
+        target: { value: 'v2.1' }
+      })
+      fireEvent.click(within(dialog).getByRole('button', { name: 'New tag' }))
+
+      // Resolve submit + schedule the 600ms close timer without firing it.
+      await act(async () => {
+        await Promise.resolve()
+        await Promise.resolve()
+      })
+      expect(git.tagCreate).toHaveBeenCalledWith('/repo', 'v2.1', null)
+
+      clearSpy.mockClear()
+      unmount()
+      // ScmNameDialog effect cleanup must clearTimeout so vitest teardown
+      // cannot fire into a destroyed env (ReferenceError: window is not defined).
+      expect(clearSpy).toHaveBeenCalled()
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1_000)
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('deletes a tag from its row after confirming', async () => {

--- a/apps/desktop/src/app/right-sidebar/review/scm-rail.tsx
+++ b/apps/desktop/src/app/right-sidebar/review/scm-rail.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type { FormEvent, ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { ActionStatus } from '@/components/ui/action-status'
 import { Button } from '@/components/ui/button'
@@ -101,6 +101,8 @@ function ScmNameDialog({
   const [value, setValue] = useState(initialValue)
   const [status, setStatus] = useState<'done' | 'idle' | 'saving'>('idle')
   const [error, setError] = useState<null | string>(null)
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
 
   const trimmed = value.trim()
   const invalid = !optional && trimmed === ''
@@ -113,6 +115,20 @@ function ScmNameDialog({
       setError(null)
     }
   }, [initialValue, open])
+
+  // Close after a brief "done" flash. Timer must clear on unmount or the
+  // callback races vitest teardown (ReferenceError: window is not defined).
+  useEffect(() => {
+    if (status !== 'done') {
+      return
+    }
+    const id = window.setTimeout(() => {
+      onCloseRef.current()
+    }, 600)
+    return () => {
+      window.clearTimeout(id)
+    }
+  }, [status])
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -127,7 +143,6 @@ function ScmNameDialog({
     try {
       await onSubmit(trimmed)
       setStatus('done')
-      window.setTimeout(onClose, 600)
     } catch (err) {
       setStatus('idle')
       setError(err instanceof Error ? err.message : t.errors.genericFailure)


### PR DESCRIPTION
## Summary
- `ScmNameDialog` scheduled `window.setTimeout(onClose, 600)` with no unmount cleanup, so vitest teardown raced into `ReferenceError: window is not defined` and failed `apps/desktop :: check:test:ui` despite all tests passing.
- Move the close delay into a `useEffect` on `status === ''done''` with `clearTimeout` cleanup, and add a regression test.

## Test plan
- [x] `pnpm exec vitest run src/app/right-sidebar/review/scm-rail.test.tsx` (16 passed)
- [ ] CI `JS & TS checks` / `check:test:ui` green on this PR