### PR TITLE
fix(desktop): clear CONNECTING stuck on local boot and WS ready races

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12330,13 +12330,30 @@ async function startHermes() {
         await advanceBootProgress('backend.watchdog', `Using watchdog prewarmed backend at ${prewarmed.baseUrl}`, 50)
         rememberLog(`Watchdog prewarmed backend ready at ${prewarmed.baseUrl}`)
         await waitForHermes(prewarmed.baseUrl, prewarmed.token)
+
+        // Match the owned local-spawn gate: HTTP-only readiness leaves the
+        // renderer forever on CONNECTING when /api/ws rejects the token.
+        const prewarmedWsUrl = buildGatewayWsUrl(prewarmed.baseUrl, prewarmed.token)
+        const prewarmedWsProbe = await probeGatewayWebSocket(prewarmedWsUrl, {
+          WebSocketImpl: globalThis.WebSocket
+        })
+
+        if (!prewarmedWsProbe.ok) {
+          rememberLog(
+            `Watchdog prewarmed backend WS probe failed (${prewarmedWsProbe.reason}); falling through to owned local serve`
+          )
+
+          return null
+        }
+
         updateBootProgress({
           phase: 'backend.ready',
-          message: 'Watchdog-managed Hermes backend is ready',
+          message: 'Hermes backend is ready. Finalizing desktop startup',
           progress: 94,
           running: true,
           error: null
         })
+        rememberLog('Watchdog-managed Hermes backend is ready (HTTP+WS)')
 
         return {
           baseUrl: prewarmed.baseUrl,
@@ -12344,7 +12361,7 @@ async function startHermes() {
           source: 'watchdog' as const,
           authMode: 'token' as const,
           token: prewarmed.token,
-          wsUrl: buildGatewayWsUrl(prewarmed.baseUrl, prewarmed.token),
+          wsUrl: prewarmedWsUrl,
           logs: hermesLog.slice(-80),
           ...getWindowState()
         }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -3,7 +3,7 @@ import { useEffect, useRef } from 'react'
 
 import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
 import type { HermesConnection } from '@/global'
-import { HermesGateway } from '@/hermes'
+import { HermesGateway, STARTUP_REQUEST_TIMEOUT_MS } from '@/hermes'
 import { translateNow } from '@/i18n'
 import { desktopDefaultCwd } from '@/lib/desktop-fs'
 import { decideLivenessForceClose, LIVENESS_REPROBE_DELAY_MS } from '@/lib/gateway-liveness-policy'
@@ -1029,6 +1029,10 @@ export function useGatewayBoot({
         )
 
         await gateway.connect(wsUrl)
+        // CONNECTING keys off $gatewayState. Re-publish immediately after
+        // connect so a missed onState race or brief activeKey drift cannot
+        // leave the overlay latched while the socket is already live.
+        reportPrimaryGatewayState(gateway.connectionState)
 
         if (cancelled) {
           return
@@ -1047,12 +1051,20 @@ export function useGatewayBoot({
           progress: 97
         })
 
+        // Bound the boot-burst REST calls. refreshHermesConfig walks profile /
+        // skill trees and can wedge under GIL pressure (20-profile cron) —
+        // hanging here used to block completeDesktopBoot() forever even with
+        // an open gateway socket.
         await Promise.all([
           // The pre-connect seed already applied the configured default; this
           // post-connect pass covers the remote backend default. Non-fatal: a
           // failed sync must not abort boot (the remembered cwd remains).
           seedDefaultCwd().catch(err => console.warn('Failed to sync default workspace cwd post-connect', err)),
-          callbacksRef.current.refreshHermesConfig(),
+          withTimeout(
+            callbacksRef.current.refreshHermesConfig(),
+            STARTUP_REQUEST_TIMEOUT_MS,
+            'Timed out loading Hermes settings during boot'
+          ).catch(err => console.warn('Boot config refresh failed', err)),
           // Session-list population is never boot-fatal. The gateway WS is
           // already open by this point — a failed sidebar fetch (transient
           // blip, or an endpoint the fallback couldn't cover) must leave the

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -430,6 +430,22 @@ function reportGatewayState(profile: string, state: ConnectionState): void {
 }
 
 export function reportPrimaryGatewayState(state: ConnectionState): void {
+  // Cold-boot CONNECTING latches on $gatewayState !== 'open'. During tile /
+  // secondary hydration, activeKey can briefly leave the primary while the
+  // primary socket itself is already open — the strict activeKey gate then
+  // drops the 'open' transition and the overlay never exits. Always mirror
+  // terminal primary transitions so CONNECTING can clear; non-terminal
+  // updates still respect the active-route gate.
+  if (state === 'open' || state === 'closed' || state === 'error') {
+    if (state === 'open') {
+      markNativeNotifyBaseline()
+    }
+
+    setGatewayState(state)
+
+    return
+  }
+
   reportGatewayState(g.primaryProfile, state)
 }
 

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -80,6 +80,44 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     client.close()
   })
 
+  it('heals when the socket is already OPEN before listeners attach', async () => {
+    const client = new JsonRpcGatewayClient({
+      socketFactory: url => {
+        const ws = new FakeWebSocket(url)
+        // Localhost warm backends can finish the handshake before connect()
+        // attaches `open` listeners — readyState alone must settle connect().
+        ws.readyState = FakeWebSocket.OPEN
+        return ws as unknown as WebSocket
+      },
+      heartbeatIntervalMs: 0,
+      heartbeatDeadlineMs: 0,
+      connectTimeoutMs: 1000
+    })
+
+    await expect(client.connect('ws://x')).resolves.toBeUndefined()
+    expect(client.connectionState).toBe('open')
+    client.close()
+  })
+
+  it('rediials after a zombie connecting state with a dead socket', async () => {
+    const client = makeClient()
+    const first = client.connect('ws://x')
+    const sock = sockets[0]
+    sock.open()
+    await first
+    expect(client.connectionState).toBe('open')
+
+    // Simulate a half-torn connection: state stuck connecting, socket gone.
+    ;(client as unknown as { state: string; socket: null }).state = 'connecting'
+    ;(client as unknown as { socket: null }).socket = null
+
+    const second = client.connect('ws://y')
+    sockets[sockets.length - 1].open()
+    await second
+    expect(client.connectionState).toBe('open')
+    client.close()
+  })
+
   it('fetches replay on reconnect for sessions it has watermarks for', async () => {
     const client = makeClient()
 

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -166,7 +166,26 @@ export class JsonRpcGatewayClient {
       throw invalidUrl()
     }
 
-    if (this.socket?.readyState === WebSocket.OPEN || this.state === 'connecting') {
+    // Heal a live socket that already completed the handshake while we were
+    // still advertising 'connecting' (missed `open` race on fast localhost).
+    // Without this, CONNECTING sticks forever and every later connect() no-ops
+    // on the early-return below.
+    if (this.socket?.readyState === WebSocket.OPEN) {
+      if (this.state !== 'open') {
+        this.setState('open')
+        void this.fetchReplay()
+      }
+
+      return
+    }
+
+    // Only short-circuit when a handshake is genuinely in flight. A zombie
+    // `connecting` with a null/dead socket must fall through and redial.
+    if (
+      this.state === 'connecting' &&
+      this.socket &&
+      this.socket.readyState === WebSocket.CONNECTING
+    ) {
       return
     }
 
@@ -241,6 +260,18 @@ export class JsonRpcGatewayClient {
 
       socket.addEventListener('open', onOpen, { once: true })
       socket.addEventListener('error', onError, { once: true })
+
+      // Localhost / warm backends can finish the handshake before listeners
+      // attach. If we miss `open`, state stays `connecting` and CONNECTING
+      // never clears — heal by sampling readyState after subscribe.
+      if (socket.readyState === WebSocket.OPEN) {
+        onOpen()
+      } else if (
+        socket.readyState === WebSocket.CLOSING ||
+        socket.readyState === WebSocket.CLOSED
+      ) {
+        onError()
+      }
 
       if (this.options.connectTimeoutMs > 0) {
         timer = setTimeout(() => {

--- a/scripts/windows/Recover-DesktopBackendAttach.ps1
+++ b/scripts/windows/Recover-DesktopBackendAttach.ps1
@@ -1,0 +1,231 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Recover Desktop <-> managed backend attach when CONNECTING hangs.
+
+.DESCRIPTION
+  Elevated operator path:
+  1) Clear burned recovery-budget.json
+  2) Force-restart Go watchdog (kills elevated zombie :9119 occupant)
+  3) Wait for %LOCALAPPDATA%\HermesWatchdog\desktop-backend.json
+  4) Relaunch packaged Desktop via start-hermes-desktop.ps1 (local+prewarm)
+
+.EXAMPLE
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\Recover-DesktopBackendAttach.ps1
+#>
+param(
+    [string]$HermesRoot = "",
+    [string]$HermesHome = "",
+    [int]$ManagedBackendPort = 9119,
+    [int]$ManifestWaitSeconds = 90
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-IsElevatedOperator {
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } catch {
+        return $false
+    }
+}
+
+if (-not (Test-IsElevatedOperator)) {
+    Write-Host "Not elevated; re-launching with UAC (click Yes)..."
+    $argList = @(
+        "-NoProfile",
+        "-ExecutionPolicy", "Bypass",
+        "-File", "`"$PSCommandPath`""
+    )
+    if (-not [string]::IsNullOrWhiteSpace($HermesRoot)) {
+        $argList += @("-HermesRoot", "`"$HermesRoot`"")
+    }
+    if (-not [string]::IsNullOrWhiteSpace($HermesHome)) {
+        $argList += @("-HermesHome", "`"$HermesHome`"")
+    }
+    $argList += @("-ManagedBackendPort", "$ManagedBackendPort", "-ManifestWaitSeconds", "$ManifestWaitSeconds")
+    $proc = Start-Process -FilePath "powershell.exe" -ArgumentList $argList -Verb RunAs -Wait -PassThru
+    exit $proc.ExitCode
+}
+
+if ([string]::IsNullOrWhiteSpace($HermesRoot)) {
+    $HermesRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+}
+if ([string]::IsNullOrWhiteSpace($HermesHome)) {
+    if (-not [string]::IsNullOrWhiteSpace($env:HERMES_HOME)) {
+        $HermesHome = $env:HERMES_HOME
+    } else {
+        $HermesHome = Join-Path $env:USERPROFILE ".hermes"
+    }
+}
+
+$dataDir = Join-Path $env:LOCALAPPDATA "HermesWatchdog"
+$manifestPath = Join-Path $dataDir "desktop-backend.json"
+$budgetPath = Join-Path $dataDir "recovery-budget.json"
+$goWatchdog = Join-Path $HermesRoot "scripts\windows\Start-HermesGoWatchdog.ps1"
+$desktopStart = Join-Path $HermesRoot "scripts\windows\start-hermes-desktop.ps1"
+$utf8NoBom = New-Object System.Text.UTF8Encoding $false
+
+function Write-Recover([string]$Message) {
+    Write-Host ("[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $Message)
+}
+
+if (-not (Test-Path -LiteralPath $goWatchdog)) {
+    throw "Missing Start-HermesGoWatchdog.ps1 at $goWatchdog"
+}
+if (-not (Test-Path -LiteralPath $desktopStart)) {
+    throw "Missing start-hermes-desktop.ps1 at $desktopStart"
+}
+
+Write-Recover ("elevated recover root={0} home={1} port={2}" -f $HermesRoot, $HermesHome, $ManagedBackendPort)
+
+function Get-ListeningPidsOnPort([int]$Port) {
+    $pids = New-Object System.Collections.Generic.HashSet[int]
+    try {
+        $conns = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue
+        foreach ($c in @($conns)) {
+            if ($c.OwningProcess -gt 0) { [void]$pids.Add([int]$c.OwningProcess) }
+        }
+    } catch {
+        # Fallback: netstat parse when Get-NetTCPConnection is unavailable.
+        $lines = netstat -ano | Select-String (":{0}\s+.*LISTENING\s+(\d+)" -f $Port)
+        foreach ($m in $lines) {
+            if ($m.Matches.Count -gt 0) {
+                $pidText = $m.Matches[0].Groups[1].Value
+                $pidVal = 0
+                if ([int]::TryParse($pidText, [ref]$pidVal) -and $pidVal -gt 0) {
+                    [void]$pids.Add($pidVal)
+                }
+            }
+        }
+    }
+    return @($pids)
+}
+
+function Stop-PortOccupants([int]$Port) {
+    # Go watchdog waitManagedPortCleared is observational only — it never
+    # TerminateProcess foreign squatters. Operator recover must force-clear.
+    for ($round = 1; $round -le 3; $round++) {
+        $owners = @(Get-ListeningPidsOnPort -Port $Port)
+        if ($owners.Count -eq 0) {
+            Write-Recover ("port {0} clear (round {1})" -f $Port, $round)
+            return $true
+        }
+        foreach ($ownerPid in $owners) {
+            Write-Recover ("force-clear port {0} occupant pid={1} (round {2})" -f $Port, $ownerPid, $round)
+            & taskkill.exe /F /T /PID $ownerPid 2>$null | Out-Null
+            Stop-Process -Id $ownerPid -Force -ErrorAction SilentlyContinue
+        }
+        Start-Sleep -Seconds 2
+    }
+    $left = @(Get-ListeningPidsOnPort -Port $Port)
+    if ($left.Count -gt 0) {
+        Write-Recover ("WARN port {0} still held by pid(s)={1}" -f $Port, ($left -join ","))
+        return $false
+    }
+    return $true
+}
+
+# 1) Clear burned recovery budget (no BOM)
+if (Test-Path -LiteralPath $budgetPath) {
+    $stamp = Get-Date -Format "yyyyMMddHHmmss"
+    Copy-Item -LiteralPath $budgetPath -Destination ("{0}.bak-attach-{1}" -f $budgetPath, $stamp) -Force
+    Remove-Item -LiteralPath $budgetPath -Force
+    Write-Recover "cleared recovery-budget.json"
+}
+
+# 2) Stop visible Desktop so it re-attaches after fresh manifest
+Get-Process -Name "Hermes" -ErrorAction SilentlyContinue | ForEach-Object {
+    Write-Recover ("stopping Hermes pid={0}" -f $_.Id)
+    Stop-Process -Id $_.Id -Force -ErrorAction SilentlyContinue
+}
+Start-Sleep -Seconds 2
+
+# 2b) Force-clear managed port squatters BEFORE watchdog ForceRestart.
+# Without this, EnsureHealthy logs "replacing occupant" then only waits 15s.
+if (-not (Stop-PortOccupants -Port $ManagedBackendPort)) {
+    throw ("Could not free managed port {0}; refuse to wait forever for desktop-backend.json" -f $ManagedBackendPort)
+}
+
+# 3) Force-restart Go watchdog (prewarm + publish desktop-backend.json)
+Write-Recover "ForceRestart Go watchdog"
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $goWatchdog `
+    -HermesRoot $HermesRoot `
+    -HermesHome $HermesHome `
+    -ManagedBackendPort $ManagedBackendPort `
+    -ForceRestart `
+    -BuildIfMissing
+if ($LASTEXITCODE -ne 0 -and $null -ne $LASTEXITCODE) {
+    throw "Start-HermesGoWatchdog exited $LASTEXITCODE"
+}
+
+# Budget may refill during ForceRestart flap — clear again before wait.
+if (Test-Path -LiteralPath $budgetPath) {
+    Remove-Item -LiteralPath $budgetPath -Force -ErrorAction SilentlyContinue
+    Write-Recover "re-cleared recovery-budget.json after ForceRestart"
+}
+
+# 4) Wait for auth-ready manifest
+$deadline = (Get-Date).AddSeconds($ManifestWaitSeconds)
+$ready = $false
+while ((Get-Date) -lt $deadline) {
+    if (Test-Path -LiteralPath $manifestPath) {
+        try {
+            $raw = [System.IO.File]::ReadAllText($manifestPath, $utf8NoBom)
+            $m = $raw | ConvertFrom-Json
+            $base = [string]$m.baseUrl
+            $token = [string]$m.token
+            if (-not [string]::IsNullOrWhiteSpace($base) -and -not [string]::IsNullOrWhiteSpace($token)) {
+                $sessionsUrl = $base.TrimEnd("/") + "/api/sessions"
+                $resp = Invoke-WebRequest -Uri $sessionsUrl -Headers @{
+                    Authorization = ("Bearer " + $token)
+                    "X-Hermes-Session-Token" = $token
+                } -UseBasicParsing -TimeoutSec 5
+                if ($resp.StatusCode -ge 200 -and $resp.StatusCode -lt 300) {
+                    Write-Recover ("manifest auth-ok url={0}" -f $base)
+                    $ready = $true
+                    break
+                }
+            }
+        } catch {
+            Write-Recover ("manifest present but not auth-ready yet: {0}" -f $_.Exception.Message)
+        }
+    } else {
+        Write-Recover "waiting for desktop-backend.json..."
+    }
+    Start-Sleep -Seconds 2
+}
+
+if (-not $ready) {
+    throw "Timed out waiting for auth-ready desktop-backend.json (${ManifestWaitSeconds}s)"
+}
+
+# 5) Strip sticky Remote env and relaunch Desktop local+prewarm
+Remove-Item Env:HERMES_DESKTOP_REMOTE_URL -ErrorAction SilentlyContinue
+Remove-Item Env:HERMES_DESKTOP_REMOTE_TOKEN -ErrorAction SilentlyContinue
+Write-Recover "launching Desktop via start-hermes-desktop.ps1"
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $desktopStart `
+    -HermesRoot $HermesRoot `
+    -Cwd $HermesRoot `
+    -HermesHome $HermesHome
+Write-Recover ("desktop launcher exit={0}" -f $LASTEXITCODE)
+
+Start-Sleep -Seconds 6
+$visible = @(Get-Process -Name "Hermes" -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne [IntPtr]::Zero })
+$port0 = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    $_.CommandLine -and $_.CommandLine -match 'serve --host 127\.0\.0\.1 --port 0'
+})
+Write-Recover ("visibleHermes={0} port0Serve={1} manifestExists={2}" -f $visible.Count, $port0.Count, (Test-Path -LiteralPath $manifestPath))
+
+if ($visible.Count -lt 1) {
+    throw "Desktop did not show a visible window"
+}
+if ($port0.Count -gt 0) {
+    Write-Warning "Desktop still owns a port-0 serve; CONNECTING may persist. Re-run this script."
+    exit 2
+}
+
+Write-Recover "RECOVER_OK: managed backend attach path ready"
+exit 0

--- a/scripts/windows/Restore-HermesDesktopLocalBoot.ps1
+++ b/scripts/windows/Restore-HermesDesktopLocalBoot.ps1
@@ -1,0 +1,84 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  Restore classic Desktop local boot (owned serve --port 0) when CONNECTING sticks on prewarm.
+
+.DESCRIPTION
+  Stops elevated watchdog (so it cannot republish desktop-backend.json / relaunch
+  elevated ghosts), quarantines the prewarm manifest, and launches Desktop via
+  start-hermes-desktop.ps1 -ForceLocalSpawn (Medium IL when elevated).
+
+.EXAMPLE
+  powershell -NoProfile -ExecutionPolicy Bypass -File scripts\windows\Restore-HermesDesktopLocalBoot.ps1
+#>
+param(
+    [string]$HermesRoot = "",
+    [string]$HermesHome = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+function Test-IsElevatedOperator {
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } catch {
+        return $false
+    }
+}
+
+if (-not (Test-IsElevatedOperator)) {
+    Write-Host "Not elevated; re-launching with UAC (click Yes)..."
+    $argList = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"")
+    if (-not [string]::IsNullOrWhiteSpace($HermesRoot)) { $argList += @("-HermesRoot", "`"$HermesRoot`"") }
+    if (-not [string]::IsNullOrWhiteSpace($HermesHome)) { $argList += @("-HermesHome", "`"$HermesHome`"") }
+    $proc = Start-Process -FilePath "powershell.exe" -ArgumentList $argList -Verb RunAs -Wait -PassThru
+    exit $proc.ExitCode
+}
+
+if ([string]::IsNullOrWhiteSpace($HermesRoot)) {
+    $HermesRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+}
+if ([string]::IsNullOrWhiteSpace($HermesHome)) {
+    $HermesHome = if ($env:HERMES_HOME) { $env:HERMES_HOME } else { Join-Path $env:USERPROFILE ".hermes" }
+}
+
+$desktopStart = Join-Path $HermesRoot "scripts\windows\start-hermes-desktop.ps1"
+$dataDir = Join-Path $env:LOCALAPPDATA "HermesWatchdog"
+$manifest = Join-Path $dataDir "desktop-backend.json"
+
+function Write-Restore([string]$Message) {
+    Write-Host ("[{0}] {1}" -f (Get-Date -Format "HH:mm:ss"), $Message)
+}
+
+Write-Restore ("restore local boot root={0}" -f $HermesRoot)
+
+Write-Restore "stopping Hermes + hermes-watchdog"
+Get-Process -Name "Hermes","hermes-watchdog" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+Start-Sleep -Seconds 2
+
+# Clear burned recovery so a later watchdog start is not circuit-open.
+$budget = Join-Path $dataDir "recovery-budget.json"
+if (Test-Path -LiteralPath $budget) {
+    Remove-Item -LiteralPath $budget -Force -ErrorAction SilentlyContinue
+    Write-Restore "cleared recovery-budget.json"
+}
+
+if (Test-Path -LiteralPath $manifest) {
+    $bak = "{0}.bak-restorelocal-{1}" -f $manifest, (Get-Date -Format "yyyyMMddHHmmss")
+    Move-Item -LiteralPath $manifest -Destination $bak -Force
+    Write-Restore ("quarantined manifest -> {0}" -f $bak)
+}
+
+Write-Restore "launching Desktop -ForceLocalSpawn"
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $desktopStart `
+    -HermesRoot $HermesRoot `
+    -Cwd $HermesRoot `
+    -HermesHome $HermesHome `
+    -ForceLocalSpawn
+
+Write-Restore ("desktop launcher exit={0}" -f $LASTEXITCODE)
+Write-Restore "Do NOT restart Go watchdog until CONNECTING clears (watchdog republishes prewarm)."
+Write-Restore "RESTORE_OK: classic local boot requested"
+exit 0

--- a/scripts/windows/start-hermes-desktop.ps1
+++ b/scripts/windows/start-hermes-desktop.ps1
@@ -1,7 +1,10 @@
 param(
     [string]$HermesRoot = "",
     [string]$Cwd = "",
-    [string]$HermesHome = ""
+    [string]$HermesHome = "",
+    # Bypass watchdog prewarm / desktop-backend.json and let Desktop spawn its
+    # own `serve --port 0` (the path that reaches "Finalizing desktop startup").
+    [switch]$ForceLocalSpawn
 )
 
 $ErrorActionPreference = "Stop"
@@ -51,13 +54,102 @@ if (-not (Test-Path -LiteralPath $PackagedExe)) {
     $PackagedExe = Join-Path $env:LOCALAPPDATA "hermes\hermes-agent\apps\desktop\release\win-unpacked\Hermes.exe"
 }
 
-# Guard: skip if a packaged Hermes.exe is already running from the resolved path.
-$packagedRunning = Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
-    $_.CommandLine -and $_.CommandLine -match [regex]::Escape($PackagedExe)
-} | Select-Object -First 1
-if ($packagedRunning) {
-    Write-Host "[start-hermes-desktop] Packaged Hermes.exe already running (pid=$($packagedRunning.ProcessId)) — skipping launch."
-    exit 0
+# Electron child processes carry "--type=..." (gpu/renderer/utility). The main
+# process does not. Boot races (Session 0 thrash, Startup folder + logon task)
+# can leave a main Hermes.exe alive with MainWindowHandle=0 — process exists,
+# no visible window. Treating that as "already running" skips logon relaunch
+# and the console user sees "desktop did not start".
+$packagedExePattern = [regex]::Escape($PackagedExe)
+$packagedProcesses = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+    $_.CommandLine -and $_.CommandLine -match $packagedExePattern
+})
+$mainProcesses = @($packagedProcesses | Where-Object {
+    $_.CommandLine -notmatch '(?i)\s--type='
+})
+
+function Test-HermesDesktopVisibleWindow {
+    param([Parameter(Mandatory = $true)][int[]]$ProcessIds)
+    foreach ($procId in $ProcessIds) {
+        if ($procId -le 0) { continue }
+        $alive = Get-Process -Id $procId -ErrorAction SilentlyContinue
+        if ($null -eq $alive) { continue }
+        if ($alive.MainWindowHandle -ne [IntPtr]::Zero) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-HermesOwnsEphemeralServe {
+    param([Parameter(Mandatory = $true)][int[]]$MainProcessIds)
+    if ($MainProcessIds.Count -eq 0) { return $false }
+    $idSet = @{}
+    foreach ($id in $MainProcessIds) { $idSet[[int]$id] = $true }
+    $ephemeral = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.CommandLine -and $_.CommandLine -match 'serve --host 127\.0\.0\.1 --port 0'
+    })
+    foreach ($svc in $ephemeral) {
+        $parent = [int]$svc.ParentProcessId
+        if ($idSet.ContainsKey($parent)) { return $true }
+        # Walk one hop: python.exe child of Hermes.exe is common on Windows.
+        $parentProc = Get-CimInstance Win32_Process -Filter "ProcessId=$parent" -ErrorAction SilentlyContinue
+        if ($null -ne $parentProc -and $idSet.ContainsKey([int]$parentProc.ParentProcessId)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+if ($mainProcesses.Count -gt 0) {
+    $mainIds = @($mainProcesses | ForEach-Object { [int]$_.ProcessId })
+    $forceRelaunch = $false
+    if (Test-HermesDesktopVisibleWindow -ProcessIds $mainIds) {
+        # Dual-backend latch: a visible window that still owns `--port 0` while
+        # the Go watchdog manages :9119 stays on the boot overlay forever.
+        # Force a clean relaunch so HERMES_DESKTOP_REMOTE_* can attach.
+        if (Test-HermesOwnsEphemeralServe -MainProcessIds $mainIds) {
+            Write-Host ("[start-hermes-desktop] Visible Hermes.exe owns ephemeral port-0 serve — restarting for managed backend attach: {0}" -f ($mainIds -join ","))
+            $forceRelaunch = $true
+            foreach ($proc in $packagedProcesses) {
+                Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
+            }
+            foreach ($svc in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+                $_.CommandLine -and $_.CommandLine -match 'serve --host 127\.0\.0\.1 --port 0'
+            })) {
+                Stop-Process -Id $svc.ProcessId -Force -ErrorAction SilentlyContinue
+            }
+            Start-Sleep -Seconds 2
+        } else {
+            Write-Host "[start-hermes-desktop] Packaged Hermes.exe already running with a visible window (pid=$($mainIds[0])) — skipping launch."
+            exit 0
+        }
+    }
+
+    if (-not $forceRelaunch) {
+        # Young mains may still be creating BrowserWindow; do not thrash them.
+        $ghostGraceSeconds = 45
+        $now = Get-Date
+        $agedGhostIds = @()
+        foreach ($main in $mainProcesses) {
+            $created = $main.CreationDate
+            if ($null -eq $created) { continue }
+            $ageSeconds = ($now - [datetime]$created).TotalSeconds
+            if ($ageSeconds -ge $ghostGraceSeconds) {
+                $agedGhostIds += [int]$main.ProcessId
+            }
+        }
+
+        if ($agedGhostIds.Count -eq 0) {
+            Write-Host "[start-hermes-desktop] Packaged Hermes.exe starting (no HWND yet, age<$ghostGraceSeconds`s) — skipping relaunch."
+            exit 0
+        }
+
+        Write-Host ("[start-hermes-desktop] Ghost Hermes.exe detected (no visible window, age>={0}s). Restarting: {1}" -f $ghostGraceSeconds, ($agedGhostIds -join ","))
+        foreach ($proc in $packagedProcesses) {
+            Stop-Process -Id $proc.ProcessId -Force -ErrorAction SilentlyContinue
+        }
+        Start-Sleep -Seconds 2
+    }
 }
 
 
@@ -81,7 +173,299 @@ if (-not (Test-Path -LiteralPath $PackagedExe)) {
 }
 
 $WorkDir = Split-Path -Parent $PackagedExe
+
+# Prefer the Go watchdog prewarmed backend via Desktop's built-in
+# resolveWatchdogPrewarmedBackend (local mode). Forcing
+# HERMES_DESKTOP_REMOTE_* against loopback marks the session as "Remote
+# gateway", blocks Settings, and on this host leaves the UI stuck on
+# CONNECTING (WS ready frame never lands / no usable shell) even when
+# /api/sessions is healthy.
+$manifestPath = Join-Path $env:LOCALAPPDATA "HermesWatchdog\desktop-backend.json"
+$managedUrl = ""
+$managedToken = ""
+
+if ($ForceLocalSpawn) {
+    # Packaged Desktop adopts desktop-backend.json before spawning. When that
+    # prewarm path stalls at progress 94 ("Watchdog-managed ... ready") without
+    # "Finalizing desktop startup", CONNECTING never clears. Quarantine the
+    # manifest so this launch takes the owned `serve --port 0` path.
+    if (Test-Path -LiteralPath $manifestPath) {
+        $stamp = Get-Date -Format "yyyyMMddHHmmss"
+        $bak = "{0}.bak-forcelocal-{1}" -f $manifestPath, $stamp
+        Move-Item -LiteralPath $manifestPath -Destination $bak -Force
+        Write-Host "[start-hermes-desktop] ForceLocalSpawn: quarantined desktop-backend.json -> $bak"
+    } else {
+        Write-Host "[start-hermes-desktop] ForceLocalSpawn: no desktop-backend.json (already clear)"
+    }
+    Remove-Item Env:HERMES_DESKTOP_REMOTE_URL -ErrorAction SilentlyContinue
+    Remove-Item Env:HERMES_DESKTOP_REMOTE_TOKEN -ErrorAction SilentlyContinue
+} else {
+$waitSeconds = 90
+$deadline = (Get-Date).AddSeconds($waitSeconds)
+while ((Get-Date) -lt $deadline) {
+    if (-not (Test-Path -LiteralPath $manifestPath)) {
+        Start-Sleep -Seconds 2
+        continue
+    }
+    try {
+        $manifest = Get-Content -LiteralPath $manifestPath -Raw -Encoding utf8 | ConvertFrom-Json
+    } catch {
+        Start-Sleep -Seconds 2
+        continue
+    }
+    $candidateUrl = [string]$manifest.baseUrl
+    $candidateToken = [string]$manifest.token
+    if ([string]::IsNullOrWhiteSpace($candidateUrl) -or [string]::IsNullOrWhiteSpace($candidateToken)) {
+        Start-Sleep -Seconds 2
+        continue
+    }
+    try {
+        $probe = Invoke-WebRequest `
+            -Uri ($candidateUrl.TrimEnd('/') + '/api/sessions') `
+            -Headers @{
+                Authorization = "Bearer $candidateToken"
+                'X-Hermes-Session-Token' = $candidateToken
+            } `
+            -UseBasicParsing `
+            -TimeoutSec 3
+        if ([int]$probe.StatusCode -ge 200 -and [int]$probe.StatusCode -lt 300) {
+            $managedUrl = $candidateUrl.Trim()
+            $managedToken = $candidateToken.Trim()
+            break
+        }
+    } catch {
+        Start-Sleep -Seconds 2
+        continue
+    }
+}
+} # end else !ForceLocalSpawn
+
+# Never leave stale REMOTE_* in the process environment — a previous shell
+# session can otherwise force Remote mode even when we want local+prewarm.
+Remove-Item Env:HERMES_DESKTOP_REMOTE_URL -ErrorAction SilentlyContinue
+Remove-Item Env:HERMES_DESKTOP_REMOTE_TOKEN -ErrorAction SilentlyContinue
+
+$useRemoteFallback = $false
+if ($managedUrl -and $managedToken) {
+    $isLoopback = $false
+    try {
+        $uri = [Uri]$managedUrl
+        $isLoopback = ($uri.Host -eq '127.0.0.1') -or ($uri.Host -eq 'localhost') -or ($uri.Host -eq '::1')
+    } catch {
+        $isLoopback = $false
+    }
+    if ($isLoopback) {
+        Write-Host "[start-hermes-desktop] Managed loopback backend ready at $managedUrl — launching local+prewarm (no HERMES_DESKTOP_REMOTE_*)"
+    } else {
+        $useRemoteFallback = $true
+        $env:HERMES_DESKTOP_REMOTE_URL = $managedUrl
+        $env:HERMES_DESKTOP_REMOTE_TOKEN = $managedToken
+        Write-Host "[start-hermes-desktop] Attaching to non-loopback managed backend $managedUrl via REMOTE env"
+    }
+} else {
+    if ($ForceLocalSpawn) {
+        Write-Host "[start-hermes-desktop] ForceLocalSpawn: Desktop will own serve --port 0 (classic local boot)"
+    } else {
+        Write-Host "[start-hermes-desktop] WARNING: managed backend not ready after ${waitSeconds}s; Desktop may spawn its own serve"
+    }
+}
+
 Write-Host "[start-hermes-desktop] Launching: $PackagedExe"
 Write-Host "[start-hermes-desktop] HERMES_DESKTOP_HERMES_ROOT=$env:HERMES_DESKTOP_HERMES_ROOT"
-Start-Process -FilePath $PackagedExe -WorkingDirectory $WorkDir
+
+function Test-IsElevatedDesktopLauncher {
+    try {
+        $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+        $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+        return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+    } catch {
+        return $false
+    }
+}
+
+function Start-HermesDesktopProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$ExePath,
+        [Parameter(Mandatory = $true)][string]$WorkDirectory,
+        [hashtable]$ExtraEnv = @{},
+        [string[]]$RemoveEnv = @()
+    )
+
+    # Elevated parents create a BrowserWindow that never gets WS_VISIBLE
+    # (HWND exists, title=Hermes, IsWindowVisible=false). Launch Medium IL
+    # via a one-shot Interactive Limited scheduled task when elevated.
+    if (Test-IsElevatedDesktopLauncher) {
+        Write-Host "[start-hermes-desktop] Launcher is elevated — starting Desktop as Medium IL (Limited task)"
+        $wrapper = Join-Path $env:TEMP ("hermes-desktop-unelevated-{0}.ps1" -f (Get-Date -Format "yyyyMMddHHmmss"))
+        $envLines = New-Object System.Collections.Generic.List[string]
+        $envLines.Add('$ErrorActionPreference = "Stop"')
+        $envLines.Add(('Set-Location -LiteralPath ''{0}''' -f ($WorkDirectory -replace "'", "''")))
+        foreach ($key in $ExtraEnv.Keys) {
+            $val = [string]$ExtraEnv[$key]
+            $envLines.Add(('$env:{0} = ''{1}''' -f $key, ($val -replace "'", "''")))
+        }
+        foreach ($key in $RemoveEnv) {
+            $envLines.Add(('Remove-Item Env:{0} -ErrorAction SilentlyContinue' -f $key))
+        }
+        $envLines.Add(('$p = Start-Process -FilePath ''{0}'' -WorkingDirectory ''{1}'' -PassThru' -f ($ExePath -replace "'", "''"), ($WorkDirectory -replace "'", "''")))
+        $envLines.Add('if ($null -eq $p) { throw "unelevated Hermes start failed" }')
+        $envLines.Add('Write-Output ("started pid={0}" -f $p.Id)')
+        $utf8NoBom = New-Object System.Text.UTF8Encoding $false
+        [System.IO.File]::WriteAllText($wrapper, (($envLines -join "`r`n") + "`r`n"), $utf8NoBom)
+
+        $taskName = "HermesDesktopUnelevatedOnce"
+        Unregister-ScheduledTask -TaskName $taskName -Confirm:$false -ErrorAction SilentlyContinue | Out-Null
+        $action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument ("-NoProfile -ExecutionPolicy Bypass -File `"$wrapper`"") -WorkingDirectory $WorkDirectory
+        # UserId must be DOMAIN\user (or MACHINE\user) — bare $env:USERNAME is
+        # rejected as 0x80070057 InvalidArgument by Register-ScheduledTask.
+        $userId = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+        $principal = New-ScheduledTaskPrincipal -UserId $userId -LogonType Interactive -RunLevel Limited
+        $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries -MultipleInstances IgnoreNew -ExecutionTimeLimit ([TimeSpan]::FromMinutes(5))
+        try {
+            Register-ScheduledTask -TaskName $taskName -Action $action -Principal $principal -Settings $settings -Force | Out-Null
+            Start-ScheduledTask -TaskName $taskName
+            Write-Host ("[start-hermes-desktop] Limited task started as {0}" -f $userId)
+        } catch {
+            Write-Host ("[start-hermes-desktop] Limited task failed ({0}); falling back to runas /trustlevel:0x20000" -f $_.Exception.Message)
+            # Medium IL without Task Scheduler. Env is baked into the wrapper already.
+            $runasArgs = '/trustlevel:0x20000 "powershell.exe -NoProfile -ExecutionPolicy Bypass -File \"{0}\""' -f $wrapper
+            Start-Process -FilePath "$env:SystemRoot\System32\runas.exe" -ArgumentList $runasArgs -Wait:$false | Out-Null
+        }
+        Start-Sleep -Seconds 4
+        $info = Get-ScheduledTaskInfo -TaskName $taskName -ErrorAction SilentlyContinue
+        if ($null -ne $info -and $info.LastTaskResult -ne 0 -and $info.LastTaskResult -ne 267009) {
+            # 267009 = still running; other codes may be transient during start.
+            Write-Host ("[start-hermes-desktop] Limited task lastResult={0}" -f $info.LastTaskResult)
+        }
+        $deadline = (Get-Date).AddSeconds(20)
+        $main = $null
+        while ((Get-Date) -lt $deadline -and $null -eq $main) {
+            $main = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+                $_.CommandLine -and $_.CommandLine -match ([regex]::Escape($ExePath)) -and $_.CommandLine -notmatch '(?i)\s--type='
+            } | Select-Object -First 1)
+            if ($null -eq $main -or $main.Count -eq 0) {
+                $main = $null
+                Start-Sleep -Seconds 1
+            }
+        }
+        if ($null -eq $main) {
+            throw "Elevated launcher failed to start a Medium-IL Hermes.exe (task/runas)"
+        }
+        return Get-Process -Id ([int]$main.ProcessId) -ErrorAction Stop
+    }
+
+    # Force CreateProcess with an explicit environment block so HERMES_HOME /
+    # HERMES_DESKTOP_HERMES_ROOT are never dropped by UseShellExecute.
+    $psi = New-Object System.Diagnostics.ProcessStartInfo
+    $psi.FileName = $ExePath
+    $psi.WorkingDirectory = $WorkDirectory
+    $psi.UseShellExecute = $false
+    $psi.CreateNoWindow = $false
+    foreach ($entry in [System.Environment]::GetEnvironmentVariables([System.EnvironmentVariableTarget]::Process).GetEnumerator()) {
+        try {
+            $psi.EnvironmentVariables[$entry.Key] = [string]$entry.Value
+        } catch {
+            # Some process-only keys are read-only on ProcessStartInfo; skip.
+        }
+    }
+    foreach ($key in $RemoveEnv) {
+        $psi.EnvironmentVariables.Remove($key) | Out-Null
+    }
+    foreach ($key in $ExtraEnv.Keys) {
+        $psi.EnvironmentVariables[$key] = [string]$ExtraEnv[$key]
+    }
+    $proc = [System.Diagnostics.Process]::Start($psi)
+    if ($null -eq $proc) {
+        throw "Failed to start Hermes Desktop: $ExePath"
+    }
+    return $proc
+}
+
+$launchExtra = @{
+    HERMES_DESKTOP_HERMES_ROOT = [string]$env:HERMES_DESKTOP_HERMES_ROOT
+    HERMES_DESKTOP_CWD = [string]$env:HERMES_DESKTOP_CWD
+    HERMES_HOME = [string]$env:HERMES_HOME
+}
+if ($env:HERMES_DESKTOP_DASHBOARD_WEB_DIST) {
+    $launchExtra['HERMES_DESKTOP_DASHBOARD_WEB_DIST'] = [string]$env:HERMES_DESKTOP_DASHBOARD_WEB_DIST
+}
+$launchRemove = @()
+if ($useRemoteFallback) {
+    $launchExtra['HERMES_DESKTOP_REMOTE_URL'] = $managedUrl
+    $launchExtra['HERMES_DESKTOP_REMOTE_TOKEN'] = $managedToken
+} else {
+    $launchRemove = @('HERMES_DESKTOP_REMOTE_URL', 'HERMES_DESKTOP_REMOTE_TOKEN')
+}
+
+$launched = Start-HermesDesktopProcess -ExePath $PackagedExe -WorkDirectory $WorkDir -ExtraEnv $launchExtra -RemoveEnv $launchRemove
+Write-Host "[start-hermes-desktop] started pid=$($launched.Id)"
+
+# Soft verify: if Desktop still spawns an ephemeral serve despite a ready
+# managed loopback backend, fall back once to REMOTE attach.
+$verifyDeadline = (Get-Date).AddSeconds(40)
+$ownedDuringVerify = $false
+while ((Get-Date) -lt $verifyDeadline) {
+    Start-Sleep -Seconds 5
+    if ($launched.HasExited) {
+        Write-Host "[start-hermes-desktop] WARNING: Hermes.exe exited during attach verify (code=$($launched.ExitCode))"
+        break
+    }
+    $owned = $false
+    $ephemeral = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.CommandLine -and $_.CommandLine -match 'serve --host 127\.0\.0\.1 --port 0'
+    })
+    foreach ($svc in $ephemeral) {
+        if ([int]$svc.ParentProcessId -eq [int]$launched.Id) {
+            $owned = $true
+            break
+        }
+        $parentProc = Get-CimInstance Win32_Process -Filter "ProcessId=$($svc.ParentProcessId)" -ErrorAction SilentlyContinue
+        if ($null -ne $parentProc -and [int]$parentProc.ParentProcessId -eq [int]$launched.Id) {
+            $owned = $true
+            break
+        }
+    }
+    if ($owned) {
+        $ownedDuringVerify = $true
+        break
+    }
+}
+
+if ($ownedDuringVerify -and $managedUrl -and $managedToken -and -not $useRemoteFallback) {
+    Write-Host "[start-hermes-desktop] prewarm path spawned port-0 — retrying once with REMOTE attach to $managedUrl"
+    try { Stop-Process -Id $launched.Id -Force -ErrorAction SilentlyContinue } catch {}
+    foreach ($svc in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.CommandLine -and $_.CommandLine -match 'serve --host 127\.0\.0\.1 --port 0'
+    })) {
+        Stop-Process -Id $svc.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+    Start-Sleep -Seconds 2
+    $retryExtra = @{
+        HERMES_DESKTOP_REMOTE_URL = $managedUrl
+        HERMES_DESKTOP_REMOTE_TOKEN = $managedToken
+        HERMES_DESKTOP_HERMES_ROOT = [string]$env:HERMES_DESKTOP_HERMES_ROOT
+        HERMES_DESKTOP_CWD = [string]$env:HERMES_DESKTOP_CWD
+        HERMES_HOME = [string]$env:HERMES_HOME
+    }
+    if ($env:HERMES_DESKTOP_DASHBOARD_WEB_DIST) {
+        $retryExtra['HERMES_DESKTOP_DASHBOARD_WEB_DIST'] = [string]$env:HERMES_DESKTOP_DASHBOARD_WEB_DIST
+    }
+    $launched = Start-HermesDesktopProcess -ExePath $PackagedExe -WorkDirectory $WorkDir -ExtraEnv $retryExtra -RemoveEnv @()
+    if ($null -eq $launched) {
+        throw "Failed to start Hermes Desktop on REMOTE fallback: $PackagedExe"
+    }
+    Write-Host "[start-hermes-desktop] REMOTE fallback started pid=$($launched.Id)"
+} elseif ($ownedDuringVerify) {
+    Write-Host "[start-hermes-desktop] ERROR: Desktop spawned ephemeral port-0 serve — dual-backend latch. Killing and failing closed."
+    try { Stop-Process -Id $launched.Id -Force -ErrorAction SilentlyContinue } catch {}
+    foreach ($svc in @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+        $_.CommandLine -and $_.CommandLine -match 'serve --host 127\.0\.0\.1 --port 0'
+    })) {
+        Stop-Process -Id $svc.ProcessId -Force -ErrorAction SilentlyContinue
+    }
+    exit 2
+} else {
+    Write-Host "[start-hermes-desktop] attach verify: no Desktop-owned port-0 serve within 40s"
+}
+
 exit 0

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -406,7 +406,25 @@ async def handle_ws(
         # burst (setup.status, session.list, ...) without a stall
         # (#60800). The skin payload is small (a dict of strings/arrays),
         # so the to_thread overhead is negligible.
-        skin_payload = await asyncio.to_thread(server.resolve_skin)
+        #
+        # Bound the wait: under GIL pressure / saturated default executors
+        # (Desktop cron ticking many profiles), to_thread(resolve_skin) can
+        # stall indefinitely. That defers gateway.ready AND the receive loop,
+        # so the Desktop overlay stays on CONNECTING with an ESTABLISHED
+        # socket that never processes RPCs or close frames.
+        _SKIN_RESOLVE_TIMEOUT_S = 5.0
+        try:
+            skin_payload = await asyncio.wait_for(
+                asyncio.to_thread(server.resolve_skin),
+                timeout=_SKIN_RESOLVE_TIMEOUT_S,
+            )
+        except Exception:
+            _log.warning(
+                "resolve_skin timed out or failed peer=%s; sending empty skin",
+                peer,
+                exc_info=True,
+            )
+            skin_payload = {}
         from tui_gateway.event_replay import EPOCH as _replay_epoch
         ready_ok = await transport.write_async(
             {


### PR DESCRIPTION
## Summary
- Heal missed WebSocket `open` handshakes and zombie `connecting` early-returns so `` can reach `open` and dismiss CONNECTING.
- Bound `resolve_skin` before `gateway.ready` so the WS receive loop is not blocked under GIL/executor pressure.
- Restore classic Desktop-owned `serve --port 0` via ForceLocalSpawn / recover scripts when watchdog prewarm drifts.

## Test plan
- [x] `pnpm --filter @hermes/shared exec vitest run src/json-rpc-gateway-replay.test.ts` (11 passed)
- [ ] CI full matrix green on this PR
- [ ] Manual: `start-hermes-desktop.ps1 -ForceLocalSpawn` clears CONNECTING on Windows

Made with [Cursor](https://cursor.com)